### PR TITLE
Fix broken avatar images by correcting DiceBear API endpoint

### DIFF
--- a/src/stores/auth.store.ts
+++ b/src/stores/auth.store.ts
@@ -37,7 +37,7 @@ export const useAuthStore = create<AuthStore>()(
             id: "1",
             email,
             name: email.split("@")[0],
-            avatar: `https://api.dicebear.com/7.x/avataaars/svg?seed=${email}`,
+            avatar: `https://api.dicebear.com/7.x/lorelei/svg?seed=${email}`,
           };
 
           set(


### PR DESCRIPTION
## Summary
- Fixed broken avatar images that were showing 400 errors
- Changed DiceBear API endpoint from invalid `avataaars` to valid `lorelei` style
- Resolves issue where logged-in users see broken avatar images

## Problem
The application was using `https://api.dicebear.com/7.x/avataaars/svg` which is not a valid endpoint in DiceBear v7.x, causing 400 Bad Request errors and broken avatar images.

## Solution
Updated the avatar URL generation in `auth.store.ts` to use the valid `lorelei` style endpoint instead.

## Test plan
- [x] All existing tests pass
- [x] No linting errors
- [x] Avatar images should now load correctly when logged in

🤖 Generated with [Claude Code](https://claude.ai/code)