### PR TITLE
fix: resolve authentication timeout and RLS errors

### DIFF
--- a/src/stores/auth.store.ts
+++ b/src/stores/auth.store.ts
@@ -288,7 +288,7 @@ export const useAuthStore = create<AuthStore>()(
               .from("users")
               .select("*")
               .eq("id", authUser.id)
-              .single();
+              .maybeSingle();
 
             const profileTime = performance.now() - profileStartTime;
             console.log(
@@ -421,7 +421,7 @@ supabase.auth.onAuthStateChange(async (event, session) => {
         .from("users")
         .select("*")
         .eq("id", session.user.id)
-        .single();
+        .maybeSingle();
 
       const profileTime = performance.now() - profileStartTime;
       console.log(


### PR DESCRIPTION
## Summary
- Fixed authentication timeout issue where profile queries would hang indefinitely
- Changed `.single()` to `.maybeSingle()` to handle missing user profiles gracefully
- Applied database migrations to auto-create user profiles on signup

## Changes
1. **Code changes** (in this PR):
   - Modified `src/stores/auth.store.ts` to use `.maybeSingle()` instead of `.single()`
   - This prevents the query from hanging when no profile exists

2. **Database migrations** (already applied):
   - Added trigger to auto-create user profiles when auth users are created
   - Added INSERT policy to allow users to create their own profiles
   - Fixed RLS policies that were causing timeouts

## Test plan
- [ ] Test login with GitHub OAuth
- [ ] Verify no timeout errors in console
- [ ] Confirm user profile is created automatically
- [ ] Check that subsequent logins work without issues

🤖 Generated with [Claude Code](https://claude.ai/code)