### PR TITLE
fix: implement emergency bypass for hanging profile queries

### DIFF
--- a/supabase/migrations/20250111000001_fix_auth_timeout_rls.sql
+++ b/supabase/migrations/20250111000001_fix_auth_timeout_rls.sql
@@ -1,0 +1,61 @@
+-- Add INSERT policy so users can create their own profiles
+CREATE POLICY "Users can insert own profile" ON users
+  FOR INSERT
+  WITH CHECK (auth.uid() = id);
+
+-- Create function to auto-create user profile on signup
+CREATE OR REPLACE FUNCTION public.handle_new_user()
+RETURNS trigger AS $$
+BEGIN
+  INSERT INTO public.users (id, email, name, avatar_url)
+  VALUES (
+    new.id,
+    new.email,
+    COALESCE(new.raw_user_meta_data->>'name', new.raw_user_meta_data->>'full_name'),
+    new.raw_user_meta_data->>'avatar_url'
+  )
+  ON CONFLICT (id) DO UPDATE SET
+    email = EXCLUDED.email,
+    name = COALESCE(EXCLUDED.name, users.name),
+    avatar_url = COALESCE(EXCLUDED.avatar_url, users.avatar_url),
+    updated_at = NOW();
+  
+  RETURN new;
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER;
+
+-- Create trigger to auto-create profiles
+DROP TRIGGER IF EXISTS on_auth_user_created ON auth.users;
+CREATE TRIGGER on_auth_user_created
+  AFTER INSERT ON auth.users
+  FOR EACH ROW EXECUTE FUNCTION public.handle_new_user();
+
+-- Also handle GitHub OAuth metadata
+CREATE OR REPLACE FUNCTION public.handle_auth_user_update()
+RETURNS trigger AS $$
+BEGIN
+  -- Update user profile with GitHub metadata if available
+  IF new.raw_user_meta_data->>'user_name' IS NOT NULL THEN
+    UPDATE public.users
+    SET 
+      github_username = new.raw_user_meta_data->>'user_name',
+      github_id = CASE 
+        WHEN new.raw_user_meta_data->>'provider_id' ~ '^\d+$' 
+        THEN (new.raw_user_meta_data->>'provider_id')::BIGINT 
+        ELSE NULL 
+      END,
+      avatar_url = COALESCE(new.raw_user_meta_data->>'avatar_url', avatar_url),
+      name = COALESCE(new.raw_user_meta_data->>'name', new.raw_user_meta_data->>'full_name', name),
+      updated_at = NOW()
+    WHERE id = new.id;
+  END IF;
+  
+  RETURN new;
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER;
+
+-- Create trigger for auth user updates
+DROP TRIGGER IF EXISTS on_auth_user_updated ON auth.users;
+CREATE TRIGGER on_auth_user_updated
+  AFTER UPDATE ON auth.users
+  FOR EACH ROW EXECUTE FUNCTION public.handle_auth_user_update();


### PR DESCRIPTION
## Summary
- Implemented emergency bypass flag to skip database profile queries that were hanging indefinitely
- Added robust timeout handling to prevent auth flow from getting stuck
- Enhanced error logging and fallback to auth metadata when database queries fail

## Problem
Users were experiencing authentication timeouts where profile queries would hang indefinitely, preventing login. This was due to RLS policy issues or database connection problems that caused the Supabase client to never resolve the query promise.

## Solution
1. **Emergency Bypass**: Added `BYPASS_PROFILE_QUERIES` flag that completely skips database queries
2. **Timeout Protection**: Wrapped all profile queries in timeout logic (2-3 seconds)
3. **Metadata Fallback**: Uses auth session metadata (name, avatar, GitHub info) when queries fail
4. **Better Error Handling**: Enhanced error logging with proper error codes and details

## Changes
- Modified `src/stores/auth.store.ts` to add bypass logic and timeout handling
- Applied database migration to fix RLS policies and add auto-create triggers
- Fixed TypeScript types for error handling

## Test plan
- [x] Test login with GitHub OAuth
- [x] Verify no timeout errors with bypass enabled
- [x] Confirm user data is populated from auth metadata
- [x] Check that auth flow completes successfully
- [x] Ensure no ESLint errors

## Notes
The `BYPASS_PROFILE_QUERIES` flag is a temporary measure. Once the underlying database connection issues are resolved, this flag should be set to `false` to re-enable profile queries.

🤖 Generated with [Claude Code](https://claude.ai/code)