### PR TITLE
Fix: Update default post-login redirect from '/' to '/dashboard'

### DIFF
--- a/src/app/auth/callback/route.ts
+++ b/src/app/auth/callback/route.ts
@@ -8,7 +8,7 @@ export async function GET(request: NextRequest) {
 
   const requestUrl = new URL(request.url);
   const code = requestUrl.searchParams.get("code");
-  const next = requestUrl.searchParams.get("next") ?? "/";
+  const next = requestUrl.searchParams.get("next") ?? "/dashboard";
   const errorParam = requestUrl.searchParams.get("error");
   const errorDescription = requestUrl.searchParams.get("error_description");
 

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -31,7 +31,7 @@ function LoginForm() {
     console.log("[Login Page] Current URL:", window.location.href);
 
     // Preserve the 'next' parameter through the OAuth flow
-    const next = searchParams.get("next") || "/";
+    const next = searchParams.get("next") || "/dashboard";
     const callbackUrl = new URL("/auth/callback", window.location.origin);
     callbackUrl.searchParams.set("next", next);
 

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -64,7 +64,7 @@ export async function middleware(request: NextRequest) {
   // Redirect authenticated users away from auth-restricted routes
   if (user && isAuthRestrictedRoute) {
     // Check if there's a 'next' parameter to redirect to
-    const next = request.nextUrl.searchParams.get("next") || "/";
+    const next = request.nextUrl.searchParams.get("next") || "/dashboard";
     return NextResponse.redirect(new URL(next, request.url));
   }
 


### PR DESCRIPTION
## Summary

- Updated default redirect value from `/` to `/dashboard` in authentication flow
- Users now land on the dashboard after successful login (which redirects to `/issues`)
- Maintains backward compatibility with explicit `next` parameter

## Changes Made

Updated default redirect values in three locations:
- **OAuth callback handler** (`/src/app/auth/callback/route.ts`) - Line 11
- **Middleware for authenticated users** (`/src/middleware.ts`) - Line 67
- **Login page default** (`/src/app/login/page.tsx`) - Line 34

## Test Plan

- [x] Updated default redirect values in all three specified locations
- [x] Verified dashboard route exists and redirects to `/issues`
- [x] Ran linting with `npm run lint` - no errors
- [x] Existing tests pass (except pre-existing auth store test issue)
- [x] Changes maintain backward compatibility with explicit `next` parameter

Closes #73

🤖 Generated with [Claude Code](https://claude.ai/code)