### PR TITLE
fix: add debug tool for organization creation

### DIFF
--- a/src/app/(dashboard)/debug-org/page.tsx
+++ b/src/app/(dashboard)/debug-org/page.tsx
@@ -1,0 +1,268 @@
+"use client";
+
+import { useEffect, useState, useCallback } from "react";
+import { Button } from "@/components/ui/button";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
+import { Loader2, AlertCircle, CheckCircle } from "lucide-react";
+import { useRouter } from "next/navigation";
+import { createClient } from "@/lib/supabase/client";
+
+interface Organization {
+  id: string;
+  name: string;
+  slug: string;
+  subscription_status: string;
+  trial_ends_at: string;
+  seats_used: number;
+  created_at: string;
+}
+
+interface UserProfile {
+  id: string;
+  email: string;
+  name: string | null;
+  github_username: string | null;
+}
+
+export default function DebugOrgPage() {
+  const [loading, setLoading] = useState(true);
+  const [creating, setCreating] = useState(false);
+  const [user, setUser] = useState<UserProfile | null>(null);
+  const [organizations, setOrganizations] = useState<Organization[]>([]);
+  const [error, setError] = useState<string | null>(null);
+  const [success, setSuccess] = useState<string | null>(null);
+  const router = useRouter();
+  const supabase = createClient();
+
+  const checkUserAndOrganizations = useCallback(async () => {
+    try {
+      setLoading(true);
+      setError(null);
+
+      // Get current user
+      const {
+        data: { user: authUser },
+        error: authError,
+      } = await supabase.auth.getUser();
+      if (authError || !authUser) {
+        setError("Not authenticated");
+        return;
+      }
+
+      // Get user profile
+      const { data: userProfile, error: profileError } = await supabase
+        .from("users")
+        .select("*")
+        .eq("id", authUser.id)
+        .single();
+
+      if (profileError) {
+        setError(`Failed to fetch user profile: ${profileError.message}`);
+        return;
+      }
+
+      setUser(userProfile);
+
+      // Get user's organizations
+      const { data: orgs, error: orgsError } = await supabase
+        .from("organizations")
+        .select(
+          `
+          id,
+          name,
+          slug,
+          subscription_status,
+          trial_ends_at,
+          seats_used,
+          created_at,
+          organization_members!inner(role)
+        `,
+        )
+        .eq("organization_members.user_id", authUser.id);
+
+      if (orgsError) {
+        setError(`Failed to fetch organizations: ${orgsError.message}`);
+        return;
+      }
+
+      setOrganizations(orgs || []);
+    } catch (err) {
+      setError(
+        `Unexpected error: ${err instanceof Error ? err.message : "Unknown error"}`,
+      );
+    } finally {
+      setLoading(false);
+    }
+  }, [supabase]);
+
+  useEffect(() => {
+    checkUserAndOrganizations();
+  }, [checkUserAndOrganizations]);
+
+  const createOrganization = async () => {
+    if (!user) return;
+
+    try {
+      setCreating(true);
+      setError(null);
+      setSuccess(null);
+
+      // Call the API route to create organization
+      const response = await fetch("/api/debug/create-organization", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+      });
+
+      const data = await response.json();
+
+      if (!response.ok) {
+        setError(data.error || "Failed to create organization");
+        return;
+      }
+
+      setSuccess(data.message);
+
+      // Refresh organizations list
+      await checkUserAndOrganizations();
+    } catch (err) {
+      setError(
+        `Unexpected error: ${err instanceof Error ? err.message : "Unknown error"}`,
+      );
+    } finally {
+      setCreating(false);
+    }
+  };
+
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center min-h-screen">
+        <Loader2 className="h-8 w-8 animate-spin" />
+      </div>
+    );
+  }
+
+  return (
+    <div className="container mx-auto p-6 max-w-4xl">
+      <Card>
+        <CardHeader>
+          <CardTitle>Organization Debug Tool</CardTitle>
+          <CardDescription>
+            Check and manage organizations for the current user
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-6">
+          {/* User Info */}
+          {user && (
+            <div className="space-y-2">
+              <h3 className="text-lg font-semibold">Current User</h3>
+              <div className="text-sm space-y-1">
+                <p>
+                  <strong>ID:</strong> {user.id}
+                </p>
+                <p>
+                  <strong>Email:</strong> {user.email}
+                </p>
+                <p>
+                  <strong>Name:</strong> {user.name || "Not set"}
+                </p>
+                <p>
+                  <strong>GitHub Username:</strong>{" "}
+                  {user.github_username || "Not set"}
+                </p>
+              </div>
+            </div>
+          )}
+
+          {/* Error/Success Messages */}
+          {error && (
+            <Alert variant="destructive">
+              <AlertCircle className="h-4 w-4" />
+              <AlertTitle>Error</AlertTitle>
+              <AlertDescription>{error}</AlertDescription>
+            </Alert>
+          )}
+
+          {success && (
+            <Alert>
+              <CheckCircle className="h-4 w-4" />
+              <AlertTitle>Success</AlertTitle>
+              <AlertDescription>{success}</AlertDescription>
+            </Alert>
+          )}
+
+          {/* Organizations */}
+          <div className="space-y-2">
+            <h3 className="text-lg font-semibold">Organizations</h3>
+            {organizations.length === 0 ? (
+              <div className="space-y-4">
+                <p className="text-sm text-muted-foreground">
+                  No organizations found for this user.
+                </p>
+                <Button
+                  onClick={createOrganization}
+                  disabled={creating}
+                  className="w-full sm:w-auto"
+                >
+                  {creating && (
+                    <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                  )}
+                  Create Default Organization
+                </Button>
+              </div>
+            ) : (
+              <div className="space-y-4">
+                {organizations.map((org) => (
+                  <Card key={org.id}>
+                    <CardContent className="pt-6">
+                      <div className="grid grid-cols-2 gap-4 text-sm">
+                        <div>
+                          <p className="text-muted-foreground">Name</p>
+                          <p className="font-medium">{org.name}</p>
+                        </div>
+                        <div>
+                          <p className="text-muted-foreground">Slug</p>
+                          <p className="font-medium">{org.slug}</p>
+                        </div>
+                        <div>
+                          <p className="text-muted-foreground">Status</p>
+                          <p className="font-medium capitalize">
+                            {org.subscription_status}
+                          </p>
+                        </div>
+                        <div>
+                          <p className="text-muted-foreground">Created</p>
+                          <p className="font-medium">
+                            {new Date(org.created_at).toLocaleDateString()}
+                          </p>
+                        </div>
+                      </div>
+                    </CardContent>
+                  </Card>
+                ))}
+              </div>
+            )}
+          </div>
+
+          {/* Actions */}
+          <div className="flex gap-4 pt-4">
+            <Button onClick={checkUserAndOrganizations} variant="outline">
+              Refresh
+            </Button>
+            <Button onClick={() => router.push("/dashboard")} variant="outline">
+              Back to Dashboard
+            </Button>
+          </div>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/src/app/api/debug/create-organization/route.ts
+++ b/src/app/api/debug/create-organization/route.ts
@@ -1,0 +1,144 @@
+import { NextResponse } from "next/server";
+import { createClient, createServiceRoleClient } from "@/lib/supabase/server";
+
+export async function POST() {
+  try {
+    // Get the current user
+    const supabase = await createClient();
+    const {
+      data: { user },
+      error: authError,
+    } = await supabase.auth.getUser();
+
+    if (authError || !user) {
+      return NextResponse.json({ error: "Not authenticated" }, { status: 401 });
+    }
+
+    // Use service role client for admin operations
+    const serviceClient = await createServiceRoleClient();
+
+    // Get user profile
+    const { data: userProfile, error: profileError } = await serviceClient
+      .from("users")
+      .select("*")
+      .eq("id", user.id)
+      .single();
+
+    if (profileError || !userProfile) {
+      return NextResponse.json(
+        { error: "Failed to fetch user profile" },
+        { status: 400 },
+      );
+    }
+
+    // Check if user already has organizations
+    const { data: existingOrgs } = await serviceClient
+      .from("organization_members")
+      .select("organization_id")
+      .eq("user_id", user.id);
+
+    if (existingOrgs && existingOrgs.length > 0) {
+      return NextResponse.json(
+        { error: "User already has organizations" },
+        { status: 400 },
+      );
+    }
+
+    // Generate slug
+    let baseSlug = "";
+    if (userProfile.github_username) {
+      baseSlug = userProfile.github_username
+        .toLowerCase()
+        .replace(/[^a-z0-9]+/g, "-");
+    } else {
+      const emailPart = userProfile.email.split("@")[0];
+      baseSlug = emailPart.toLowerCase().replace(/[^a-z0-9]+/g, "-");
+    }
+
+    baseSlug = baseSlug.replace(/^-+|-+$/g, "");
+    if (!baseSlug) {
+      baseSlug = "user";
+    }
+
+    // Ensure unique slug
+    let slug = baseSlug;
+    let counter = 0;
+
+    while (true) {
+      const { data: existing } = await serviceClient
+        .from("organizations")
+        .select("id")
+        .eq("slug", slug)
+        .single();
+
+      if (!existing) break;
+
+      counter++;
+      slug = `${baseSlug}-${counter}`;
+    }
+
+    // Create organization
+    const orgName =
+      userProfile.name ||
+      userProfile.github_username ||
+      userProfile.email.split("@")[0];
+
+    const { data: newOrg, error: createError } = await serviceClient
+      .from("organizations")
+      .insert({
+        name: orgName,
+        slug: slug,
+        subscription_status: "trial",
+        trial_ends_at: new Date(
+          Date.now() + 30 * 24 * 60 * 60 * 1000,
+        ).toISOString(),
+        seats_used: 1,
+      })
+      .select()
+      .single();
+
+    if (createError) {
+      return NextResponse.json(
+        { error: `Failed to create organization: ${createError.message}` },
+        { status: 400 },
+      );
+    }
+
+    // Add user as owner
+    const { error: memberError } = await serviceClient
+      .from("organization_members")
+      .insert({
+        organization_id: newOrg.id,
+        user_id: user.id,
+        role: "owner",
+        joined_at: new Date().toISOString(),
+      });
+
+    if (memberError) {
+      return NextResponse.json(
+        { error: `Failed to add user as owner: ${memberError.message}` },
+        { status: 400 },
+      );
+    }
+
+    // Log activity
+    await serviceClient.from("activities").insert({
+      organization_id: newOrg.id,
+      user_id: user.id,
+      type: "member_joined",
+      description: `Organization created for existing user ${userProfile.email}`,
+    });
+
+    return NextResponse.json({
+      success: true,
+      organization: newOrg,
+      message: `Successfully created organization "${orgName}" with slug "${slug}"`,
+    });
+  } catch (error) {
+    console.error("Error creating organization:", error);
+    return NextResponse.json(
+      { error: "Internal server error" },
+      { status: 500 },
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- Adds a debug page at `/debug-org` to help users who signed up before the organization system was implemented
- Provides a way to check and create organizations for early users
- Temporary diagnostic tool that can be removed once all users have been migrated

## Problem
Users who created accounts before the organization system was added don't have any organizations, which prevents them from using features like repository connection.

## Solution
This PR adds:
1. **Debug page** (`/debug-org`) that shows:
   - Current user details
   - List of user's organizations
   - Button to create a default organization if none exist

2. **API route** (`/api/debug/create-organization`) that:
   - Uses service role to bypass RLS policies
   - Creates an organization following the same logic as the auto-migration
   - Ensures unique slug generation
   - Adds the user as owner

## Testing
1. Navigate to `/debug-org` when logged in
2. If you have no organizations, click "Create Default Organization"
3. The organization will be created and you can proceed to `/repositories`

## Note
This is a temporary tool. Once all existing users have organizations, this can be safely removed.

🤖 Generated with [Claude Code](https://claude.ai/code)