### PR TITLE
fix: add missing description column to organizations table

### DIFF
--- a/src/types/organization.ts
+++ b/src/types/organization.ts
@@ -2,6 +2,7 @@ export interface Organization {
   id: string;
   name: string;
   slug: string;
+  description?: string;
   subscription_status: "trial" | "active" | "inactive" | "cancelled";
   subscription_id?: string;
   trial_ends_at?: string;

--- a/supabase/migrations/20250112000001_add_organization_description.sql
+++ b/supabase/migrations/20250112000001_add_organization_description.sql
@@ -1,0 +1,8 @@
+-- Add description column to organizations table
+ALTER TABLE organizations ADD COLUMN description TEXT;
+
+-- Update existing rows to have NULL description (which is fine since it's optional)
+-- No action needed as column will default to NULL
+
+-- Add comment to describe the column
+COMMENT ON COLUMN organizations.description IS 'Optional description of the organization';


### PR DESCRIPTION
## Summary
- Added missing `description` column to the `organizations` table
- Updated TypeScript types to include optional description field
- Fixed schema mismatch error preventing organization creation

## Issue
Closes #14

## Problem
When users tried to create an organization on the onboarding page, they encountered an error:
```
Error creating organization: {code: 'PGRST204', details: null, hint: null, message: "Could not find the 'description' column of 'organizations' in the schema cache"}
```

## Solution
- Created migration `20250112000001_add_organization_description.sql` to add the missing column
- Updated the `Organization` TypeScript interface to include the optional `description?: string` field

## Test plan
- [ ] Apply migration to local database
- [ ] Test organization creation flow locally
- [ ] Verify description field is properly handled

🤖 Generated with [Claude Code](https://claude.ai/code)