### PR TITLE
Fix: Enable RLS on organization_members and remove auto-org trigger

### DIFF
--- a/supabase/migrations/20250712092131_enable_organization_members_rls.sql
+++ b/supabase/migrations/20250712092131_enable_organization_members_rls.sql
@@ -1,0 +1,16 @@
+-- Enable RLS on organization_members table
+-- This fixes the issue where users cannot create organizations due to RLS being disabled
+ALTER TABLE organization_members ENABLE ROW LEVEL SECURITY;
+
+-- Verify RLS is enabled
+DO $$ 
+BEGIN 
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_class 
+    WHERE relname = 'organization_members' 
+    AND relnamespace = 'public'::regnamespace 
+    AND relrowsecurity = true
+  ) THEN
+    RAISE EXCEPTION 'RLS was not properly enabled on organization_members table';
+  END IF;
+END $$;

--- a/supabase/migrations/20250712092145_remove_auto_org_creation_trigger.sql
+++ b/supabase/migrations/20250712092145_remove_auto_org_creation_trigger.sql
@@ -1,0 +1,17 @@
+-- Remove the auto-organization creation trigger
+-- This allows users to go through the proper onboarding flow
+DROP TRIGGER IF EXISTS create_organization_on_user_signup ON users;
+
+-- Also drop the function if it's no longer needed
+DROP FUNCTION IF EXISTS create_default_organization_for_user();
+
+-- Verify the trigger has been removed
+DO $$ 
+BEGIN 
+  IF EXISTS (
+    SELECT 1 FROM pg_trigger 
+    WHERE tgname = 'create_organization_on_user_signup'
+  ) THEN
+    RAISE EXCEPTION 'Trigger create_organization_on_user_signup was not properly removed';
+  END IF;
+END $$;


### PR DESCRIPTION
## Summary

This PR fixes the critical bug preventing users from creating organizations during onboarding.

### Issues Fixed:
- ✅ Enable Row Level Security on `organization_members` table 
- ✅ Remove auto-organization creation trigger that was interfering with manual onboarding

### Root Cause

The production database had two issues:
1. RLS was disabled on the `organization_members` table, causing inserts to fail with 403 errors
2. An auto-organization creation trigger was still active, conflicting with the manual onboarding flow

### Changes Made

Created two migrations:
- `20250712092131_enable_organization_members_rls.sql` - Enables RLS on organization_members table
- `20250712092145_remove_auto_org_creation_trigger.sql` - Removes the auto-org creation trigger

### Testing

- [x] Migrations applied successfully to production
- [x] Verified RLS is now enabled on organization_members table
- [x] Verified auto-org trigger has been removed
- [x] Security advisor no longer reports RLS errors

Users should now be able to successfully create organizations through the onboarding page at `/onboarding`.

🤖 Generated with [Claude Code](https://claude.ai/code)