### PR TITLE
Fix: GitHub OAuth users cannot create organizations

### DIFF
--- a/src/app/api/organizations/check-slug/__tests__/route.test.ts
+++ b/src/app/api/organizations/check-slug/__tests__/route.test.ts
@@ -1,0 +1,188 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { GET } from "../route";
+import { NextRequest } from "next/server";
+import { createClient } from "@/lib/supabase/server";
+import { createServerClient } from "@supabase/ssr";
+
+// Mock dependencies
+vi.mock("@/lib/supabase/server", () => ({
+  createClient: vi.fn(),
+}));
+
+vi.mock("@supabase/ssr", () => ({
+  createServerClient: vi.fn(),
+}));
+
+vi.mock("next/headers", () => ({
+  cookies: vi.fn(() => Promise.resolve({
+    get: vi.fn(),
+    set: vi.fn(),
+    delete: vi.fn(),
+    getAll: vi.fn(() => []),
+  })),
+}));
+
+describe("GET /api/organizations/check-slug", () => {
+  const mockAuthClient = {
+    auth: {
+      getUser: vi.fn(),
+    },
+  };
+
+  interface MockServiceClient {
+    from: ReturnType<typeof vi.fn>;
+    select: ReturnType<typeof vi.fn>;
+    eq: ReturnType<typeof vi.fn>;
+    maybeSingle: ReturnType<typeof vi.fn>;
+  }
+
+  const mockServiceClient: MockServiceClient = {
+    from: vi.fn(),
+    select: vi.fn(),
+    eq: vi.fn(),
+    maybeSingle: vi.fn(),
+  };
+
+  // Setup chain methods
+  mockServiceClient.from.mockReturnValue(mockServiceClient);
+  mockServiceClient.select.mockReturnValue(mockServiceClient);
+  mockServiceClient.eq.mockReturnValue(mockServiceClient);
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(createClient).mockResolvedValue(mockAuthClient as ReturnType<typeof createClient>);
+    vi.mocked(createServerClient).mockReturnValue(mockServiceClient as ReturnType<typeof createServerClient>);
+  });
+
+  it("should return 400 if slug is missing", async () => {
+    const request = new NextRequest("http://localhost:3000/api/organizations/check-slug");
+    const response = await GET(request);
+    const data = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(data.error).toBe("Slug must be at least 2 characters long");
+  });
+
+  it("should return 400 if slug is too short", async () => {
+    const request = new NextRequest("http://localhost:3000/api/organizations/check-slug?slug=a");
+    const response = await GET(request);
+    const data = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(data.error).toBe("Slug must be at least 2 characters long");
+  });
+
+  it("should return 400 for invalid slug format", async () => {
+    const request = new NextRequest("http://localhost:3000/api/organizations/check-slug?slug=Test-Org");
+    const response = await GET(request);
+    const data = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(data.error).toBe("Invalid slug format");
+  });
+
+  it("should return 401 if user is not authenticated", async () => {
+    mockAuthClient.auth.getUser.mockResolvedValueOnce({
+      data: { user: null },
+      error: new Error("Unauthorized"),
+    });
+
+    const request = new NextRequest("http://localhost:3000/api/organizations/check-slug?slug=test-org");
+    const response = await GET(request);
+    const data = await response.json();
+
+    expect(response.status).toBe(401);
+    expect(data.error).toBe("Unauthorized");
+  });
+
+  it("should return available: true if slug is not taken", async () => {
+    mockAuthClient.auth.getUser.mockResolvedValueOnce({
+      data: { user: { id: "user-123" } },
+      error: null,
+    });
+
+    mockServiceClient.maybeSingle.mockResolvedValueOnce({
+      data: null,
+      error: null,
+    });
+
+    const request = new NextRequest("http://localhost:3000/api/organizations/check-slug?slug=new-org");
+    const response = await GET(request);
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(data.available).toBe(true);
+    expect(mockServiceClient.from).toHaveBeenCalledWith("organizations");
+    expect(mockServiceClient.eq).toHaveBeenCalledWith("slug", "new-org");
+  });
+
+  it("should return available: false if slug is taken", async () => {
+    mockAuthClient.auth.getUser.mockResolvedValueOnce({
+      data: { user: { id: "user-123" } },
+      error: null,
+    });
+
+    mockServiceClient.maybeSingle.mockResolvedValueOnce({
+      data: { id: "org-123" },
+      error: null,
+    });
+
+    const request = new NextRequest("http://localhost:3000/api/organizations/check-slug?slug=existing-org");
+    const response = await GET(request);
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(data.available).toBe(false);
+  });
+
+  it("should handle database errors gracefully", async () => {
+    mockAuthClient.auth.getUser.mockResolvedValueOnce({
+      data: { user: { id: "user-123" } },
+      error: null,
+    });
+
+    mockServiceClient.maybeSingle.mockResolvedValueOnce({
+      data: null,
+      error: new Error("Database error"),
+    });
+
+    const request = new NextRequest("http://localhost:3000/api/organizations/check-slug?slug=test-org");
+    const response = await GET(request);
+    const data = await response.json();
+
+    expect(response.status).toBe(500);
+    expect(data.error).toBe("Failed to check slug availability");
+  });
+
+  it("should validate slug formats correctly", async () => {
+    mockAuthClient.auth.getUser.mockResolvedValue({
+      data: { user: { id: "user-123" } },
+      error: null,
+    });
+
+    mockServiceClient.maybeSingle.mockResolvedValue({
+      data: null,
+      error: null,
+    });
+
+    // Valid slugs
+    const validSlugs = ["test", "test-org", "my-awesome-org", "org123", "123org"];
+    for (const slug of validSlugs) {
+      const request = new NextRequest(`http://localhost:3000/api/organizations/check-slug?slug=${slug}`);
+      const response = await GET(request);
+      const data = await response.json();
+      expect(response.status).toBe(200);
+      expect(data.available).toBe(true);
+    }
+
+    // Invalid slugs
+    const invalidSlugs = ["Test", "test org", "test_org", "test-", "-test", "test--org"];
+    for (const slug of invalidSlugs) {
+      const request = new NextRequest(`http://localhost:3000/api/organizations/check-slug?slug=${slug}`);
+      const response = await GET(request);
+      const data = await response.json();
+      expect(response.status).toBe(400);
+      expect(data.error).toBe("Invalid slug format");
+    }
+  });
+});

--- a/src/app/api/organizations/check-slug/route.ts
+++ b/src/app/api/organizations/check-slug/route.ts
@@ -1,0 +1,80 @@
+import { NextRequest, NextResponse } from "next/server";
+import { createClient } from "@/lib/supabase/server";
+import { createServerClient } from "@supabase/ssr";
+import { cookies } from "next/headers";
+
+export async function GET(request: NextRequest) {
+  try {
+    const searchParams = request.nextUrl.searchParams;
+    const slug = searchParams.get("slug");
+
+    if (!slug || slug.length < 2) {
+      return NextResponse.json(
+        { error: "Slug must be at least 2 characters long" },
+        { status: 400 }
+      );
+    }
+
+    // Validate slug format
+    const slugRegex = /^[a-z0-9]+(?:-[a-z0-9]+)*$/;
+    if (!slugRegex.test(slug)) {
+      return NextResponse.json(
+        { error: "Invalid slug format" },
+        { status: 400 }
+      );
+    }
+
+    // Get authenticated user
+    const supabase = await createClient();
+    const {
+      data: { user },
+      error: authError,
+    } = await supabase.auth.getUser();
+
+    if (authError || !user) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    // Create a service role client to bypass RLS
+    const cookieStore = await cookies();
+    const serviceRoleClient = createServerClient(
+      process.env.NEXT_PUBLIC_SUPABASE_URL!,
+      process.env.SUPABASE_SERVICE_ROLE_KEY!,
+      {
+        cookies: {
+          getAll() {
+            return cookieStore.getAll();
+          },
+          setAll(cookiesToSet) {
+            cookiesToSet.forEach(({ name, value, options }) =>
+              cookieStore.set(name, value, options),
+            );
+          },
+        },
+      }
+    );
+
+    // Check if slug exists
+    const { data: existingOrg, error } = await serviceRoleClient
+      .from("organizations")
+      .select("id")
+      .eq("slug", slug)
+      .maybeSingle();
+
+    if (error) {
+      console.error("Error checking slug availability:", error);
+      return NextResponse.json(
+        { error: "Failed to check slug availability" },
+        { status: 500 }
+      );
+    }
+
+    return NextResponse.json({ available: !existingOrg });
+  } catch (error) {
+    console.error("Error in slug check:", error);
+    return NextResponse.json(
+      { error: "Failed to check slug availability" },
+      { status: 500 }
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- Created new API endpoint `/api/organizations/check-slug` to handle slug availability checks
- Updated `CreateOrganizationForm` to use the API endpoint instead of direct database queries
- Fixed 500 errors that prevented new GitHub OAuth users from creating organizations

## Problem
New users signing up with GitHub OAuth were unable to create organizations due to Row Level Security (RLS) policies. The frontend was making direct database queries to check slug availability, but new users don't have SELECT permissions on the organizations table until they belong to an organization.

## Solution
Instead of querying the database directly from the frontend, I created a dedicated API endpoint that uses a service role client to bypass RLS policies. This allows the slug availability check to work for all authenticated users, regardless of their organization membership status.

## Test plan
- [x] Created comprehensive test suite for the new `/api/organizations/check-slug` endpoint
- [x] Tested various edge cases including invalid slugs, authentication errors, and database errors
- [x] All organization-related tests pass successfully
- [ ] Manual testing: Sign up with a new GitHub account and verify organization creation works
- [ ] Verify slug availability checking works in real-time as user types

🤖 Generated with [Claude Code](https://claude.ai/code)