### PR TITLE
fix: remove non-existent 'plan' field from organization creation

### DIFF
--- a/src/app/api/organizations/__tests__/route.test.ts
+++ b/src/app/api/organizations/__tests__/route.test.ts
@@ -129,7 +129,6 @@ describe("POST /api/organizations", () => {
       name: "Test Organization",
       slug: "test-org",
       description: "Test description",
-      plan: "free",
     };
 
     mockAuthClient.auth.getUser.mockResolvedValue({
@@ -176,7 +175,6 @@ describe("POST /api/organizations", () => {
       name: "Test Organization",
       slug: "test-org",
       description: "Test description",
-      plan: "free",
     });
 
     // Verify user was added as owner
@@ -239,7 +237,6 @@ describe("POST /api/organizations", () => {
       name: "Test",
       slug: "test",
       description: null,
-      plan: "free",
     };
 
     mockAuthClient.auth.getUser.mockResolvedValue({

--- a/src/app/api/organizations/route.ts
+++ b/src/app/api/organizations/route.ts
@@ -79,7 +79,7 @@ export async function POST(request: NextRequest) {
     }
 
     // Create organization
-    console.log("Creating organization with data:", { name, slug, description, plan: "free" });
+    console.log("Creating organization with data:", { name, slug, description });
     
     const { data: organization, error: orgError } = await serviceRoleClient
       .from("organizations")
@@ -87,7 +87,6 @@ export async function POST(request: NextRequest) {
         name,
         slug,
         description: description || null,
-        plan: "free",
       })
       .select()
       .single();

--- a/src/app/api/test-org/route.ts
+++ b/src/app/api/test-org/route.ts
@@ -51,7 +51,6 @@ export async function GET() {
         name: "Test Organization",
         slug: testSlug,
         description: "Test organization created for debugging",
-        plan: "free",
       })
       .select()
       .single();


### PR DESCRIPTION
- Remove 'plan' field from organization creation in API endpoints
- The organizations table uses 'subscription_status' instead of 'plan'
- This was causing 500 errors due to PGRST204 column not found error
- Update tests to match the actual database schema