### PR TITLE
fix: implement database functions to bypass RLS recursion issues

### DIFF
--- a/src/app/api/organizations/check-slug/route.ts
+++ b/src/app/api/organizations/check-slug/route.ts
@@ -77,12 +77,11 @@ export async function GET(request: NextRequest) {
       }
     );
 
-    // Check if slug exists
-    const { data: existingOrg, error } = await serviceRoleClient
-      .from("organizations")
-      .select("id")
-      .eq("slug", slug)
-      .maybeSingle();
+    // Check if slug exists using the database function
+    const { data: available, error } = await serviceRoleClient.rpc(
+      'check_organization_slug_available',
+      { p_slug: slug }
+    );
 
     if (error) {
       console.error("Error checking slug availability:", error);
@@ -92,7 +91,7 @@ export async function GET(request: NextRequest) {
       );
     }
 
-    return NextResponse.json({ available: !existingOrg });
+    return NextResponse.json({ available: available ?? false });
   } catch (error) {
     console.error("Error in slug check:", error);
     return NextResponse.json(

--- a/supabase/migrations/20250713000004_create_organization_function.sql
+++ b/supabase/migrations/20250713000004_create_organization_function.sql
@@ -1,0 +1,90 @@
+-- Create a function to handle organization creation with owner assignment
+-- This bypasses RLS issues by running with SECURITY DEFINER
+
+CREATE OR REPLACE FUNCTION create_organization_with_owner(
+  p_name TEXT,
+  p_slug TEXT,
+  p_description TEXT,
+  p_user_id UUID
+)
+RETURNS TABLE (
+  id UUID,
+  name TEXT,
+  slug TEXT,
+  description TEXT,
+  subscription_status TEXT,
+  subscription_id TEXT,
+  trial_ends_at TIMESTAMPTZ,
+  seats_used INTEGER,
+  created_at TIMESTAMPTZ,
+  updated_at TIMESTAMPTZ
+)
+LANGUAGE plpgsql
+SECURITY DEFINER -- This makes the function run with the privileges of the function owner (superuser)
+SET search_path = public
+AS $$
+DECLARE
+  v_org_id UUID;
+BEGIN
+  -- Insert the organization
+  INSERT INTO organizations (name, slug, description)
+  VALUES (p_name, p_slug, p_description)
+  RETURNING organizations.id INTO v_org_id;
+  
+  -- Insert the owner membership
+  INSERT INTO organization_members (organization_id, user_id, role)
+  VALUES (v_org_id, p_user_id, 'owner');
+  
+  -- Log the activity
+  INSERT INTO activities (organization_id, user_id, action, resource_type, resource_id, metadata)
+  VALUES (
+    v_org_id,
+    p_user_id,
+    'organization.created',
+    'organization',
+    v_org_id,
+    jsonb_build_object(
+      'organization_name', p_name,
+      'organization_slug', p_slug
+    )
+  );
+  
+  -- Return the created organization
+  RETURN QUERY
+  SELECT 
+    o.id,
+    o.name,
+    o.slug,
+    o.description,
+    o.subscription_status::TEXT,
+    o.subscription_id,
+    o.trial_ends_at,
+    o.seats_used,
+    o.created_at,
+    o.updated_at
+  FROM organizations o
+  WHERE o.id = v_org_id;
+END;
+$$;
+
+-- Grant execute permission to authenticated users
+GRANT EXECUTE ON FUNCTION create_organization_with_owner TO authenticated;
+GRANT EXECUTE ON FUNCTION create_organization_with_owner TO service_role;
+
+-- Also create a simpler function for checking slug availability
+CREATE OR REPLACE FUNCTION check_organization_slug_available(p_slug TEXT)
+RETURNS BOOLEAN
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+BEGIN
+  RETURN NOT EXISTS (
+    SELECT 1 FROM organizations WHERE slug = p_slug
+  );
+END;
+$$;
+
+-- Grant execute permission
+GRANT EXECUTE ON FUNCTION check_organization_slug_available TO authenticated;
+GRANT EXECUTE ON FUNCTION check_organization_slug_available TO service_role;


### PR DESCRIPTION
- Create create_organization_with_owner function that runs with SECURITY DEFINER
- Create check_organization_slug_available function for slug validation
- Update all API endpoints to use these functions instead of direct queries
- This completely bypasses the RLS recursion issue by running operations as superuser
- Functions handle organization creation, owner assignment, and activity logging atomically