### PR TITLE
Fix organization creation logging

### DIFF
--- a/src/app/api/debug/create-organization/route.ts
+++ b/src/app/api/debug/create-organization/route.ts
@@ -162,9 +162,8 @@ export async function POST() {
       await serviceClient.from("activities").insert({
         organization_id: newOrg.id,
         user_id: user.id,
-        action: "organization.created",
-        resource_type: "organization",
-        resource_id: newOrg.id,
+        type: "member_joined",
+        description: "organization.created",
         metadata: {
           description: `Organization created for existing user ${userProfile.email}`,
         },

--- a/src/app/api/projects/route.ts
+++ b/src/app/api/projects/route.ts
@@ -100,9 +100,9 @@ export async function POST(request: NextRequest) {
     const { error: activityError } = await supabase.from("activities").insert({
       organization_id,
       user_id: user.id,
-      action: "project.created",
-      resource_type: "project",
-      resource_id: project.id,
+      project_id: project.id,
+      type: "project_created",
+      description: "project.created",
       metadata: {
         project_name: name,
         repository_id,

--- a/src/app/api/repositories/connect/route.ts
+++ b/src/app/api/repositories/connect/route.ts
@@ -144,9 +144,9 @@ export async function POST(request: NextRequest) {
     const { error: activityError } = await supabase.from("activities").insert({
       organization_id,
       user_id: user.id,
-      action: "repositories.connected",
-      resource_type: "repository",
-      resource_id: insertedRepos?.[0]?.id,
+      repository_id: insertedRepos?.[0]?.id,
+      type: "repository_connected",
+      description: "repositories.connected",
       metadata: {
         count: insertedRepos?.length || 0,
         repository_names:

--- a/src/app/api/repositories/disconnect/route.ts
+++ b/src/app/api/repositories/disconnect/route.ts
@@ -60,8 +60,8 @@ export async function POST(request: NextRequest) {
     const { error: activityError } = await supabase.from("activities").insert({
       organization_id,
       user_id: user.id,
-      action: "repositories.disconnected",
-      resource_type: "repository",
+      type: "repository_connected",
+      description: "repositories.disconnected",
       metadata: {
         count: deletedRepos?.length || 0,
         repository_names:

--- a/supabase/migrations/20250111000005_debug_org_function.sql
+++ b/supabase/migrations/20250111000005_debug_org_function.sql
@@ -51,14 +51,19 @@ BEGIN
   INSERT INTO organization_members (organization_id, user_id, role, joined_at)
   VALUES (v_org_id, p_user_id, 'owner', NOW());
   
-  -- Log activity
-  INSERT INTO activities (organization_id, user_id, action, resource_type, resource_id, metadata)
+  -- Log activity using existing columns
+  INSERT INTO activities (
+    organization_id,
+    user_id,
+    type,
+    description,
+    metadata
+  )
   VALUES (
     v_org_id,
     p_user_id,
+    'member_joined',
     'organization.created',
-    'organization',
-    v_org_id,
     jsonb_build_object('description', 'Organization created via debug tool')
   );
   

--- a/supabase/migrations/20250713000004_create_organization_function.sql
+++ b/supabase/migrations/20250713000004_create_organization_function.sql
@@ -35,14 +35,19 @@ BEGIN
   INSERT INTO organization_members (organization_id, user_id, role)
   VALUES (v_org_id, p_user_id, 'owner');
   
-  -- Log the activity
-  INSERT INTO activities (organization_id, user_id, action, resource_type, resource_id, metadata)
+  -- Log the activity using existing columns
+  INSERT INTO activities (
+    organization_id,
+    user_id,
+    type,
+    description,
+    metadata
+  )
   VALUES (
     v_org_id,
     p_user_id,
+    'member_joined',
     'organization.created',
-    'organization',
-    v_org_id,
     jsonb_build_object(
       'organization_name', p_name,
       'organization_slug', p_slug


### PR DESCRIPTION
## Summary
- fix stored procedures to use existing columns in `activities`
- update API routes to align with current schema

## Testing
- `npx eslint src/app/api/debug/create-organization/route.ts src/app/api/projects/route.ts src/app/api/repositories/connect/route.ts src/app/api/repositories/disconnect/route.ts`
- `npx prettier -w src/app/api/debug/create-organization/route.ts src/app/api/projects/route.ts src/app/api/repositories/connect/route.ts src/app/api/repositories/disconnect/route.ts`
- `npx tsc --noEmit` *(fails: errors in test files)*
- `npm test` *(fails: several tests fail due to missing env vars and timeouts)*

------
https://chatgpt.com/codex/tasks/task_b_68730184ac54832ba65338dc6f899a2b