### PR TITLE
fix: resolve onboarding GitHub redirect issue

### DIFF
--- a/e2e/onboarding-github-flow.spec.ts
+++ b/e2e/onboarding-github-flow.spec.ts
@@ -1,0 +1,123 @@
+import { test, expect } from "@playwright/test";
+
+test.describe("Onboarding GitHub Flow", () => {
+  let testUserId: string;
+  let testWorkspaceId: string;
+
+  test.beforeEach(async ({ page }) => {
+    // For e2e tests, we'll use test fixtures or mock data
+    // In a real scenario, you'd set up test data using a test database
+    testUserId = "test-user-" + Date.now();
+    testWorkspaceId = "test-workspace-" + Date.now();
+
+    // Mock authentication by setting session
+    await page.goto("/");
+    await page.evaluate((userId) => {
+      localStorage.setItem("test-user-id", userId);
+    }, testUserId);
+  });
+
+  test.afterEach(async () => {
+    // Clean up would happen here in a real test environment
+    // For now, we'll just clear the test data references
+    testUserId = "";
+    testWorkspaceId = "";
+  });
+
+  test("completes onboarding flow and connects GitHub", async ({ page }) => {
+    // Go to workspace creation page
+    await page.goto("/onboarding/workspace");
+    
+    // Fill in workspace form
+    await page.fill('input[name="name"]', "My Test Workspace");
+    await expect(page.locator('input[name="slug"]')).toHaveValue("my-test-workspace");
+    
+    // Submit workspace creation
+    await page.click('button:has-text("Create Workspace")');
+    
+    // Should redirect to welcome page
+    await expect(page).toHaveURL("/onboarding/welcome");
+    
+    // Navigate through welcome slides
+    await expect(page.locator("h1")).toContainText("Welcome to Daygent");
+    await page.click('button:has-text("Next")');
+    
+    await expect(page.locator("h1")).toContainText("AI-Powered Development");
+    await page.click('button:has-text("Next")');
+    
+    await expect(page.locator("h1")).toContainText("GitHub Integration");
+    
+    // Mock the GitHub App installation API
+    await page.route("/api/github/install", async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          install_url: "https://github.com/apps/test-app/installations/new?state=test-state",
+        }),
+      });
+    });
+    
+    // Click Connect with GitHub
+    const connectButton = page.locator('button:has-text("Connect with GitHub")');
+    await expect(connectButton).toBeVisible();
+    
+    // Intercept the redirect to GitHub
+    await page.on("framenavigated", (frame) => {
+      if (frame.url().includes("github.com/apps")) {
+        console.log("Redirecting to GitHub App installation:", frame.url());
+      }
+    });
+    
+    // Click the button
+    await connectButton.click();
+    
+    // Should show loading state
+    await expect(page.locator('button:has-text("Connecting...")')).toBeVisible();
+    
+    // In a real test, we would verify the redirect to GitHub
+    // For now, we'll simulate the callback
+    await page.goto(`/api/github/install/callback?installation_id=12345&code=test-code&state=${testWorkspaceId}:csrf-token`);
+    
+    // Should redirect to the workspace issues page
+    await expect(page).toHaveURL(/\/[\w-]+\/issues$/);
+  });
+
+  test("shows import issues button on empty state", async ({ page }) => {
+    // Navigate directly to issues page
+    await page.goto(`/test-workspace-${Date.now()}/issues`);
+    
+    // Should show empty state
+    await expect(page.locator("h3")).toContainText("Connect a repository first");
+    
+    // Should have button to connect repositories
+    const connectRepoButton = page.locator('a:has-text("Connect Repositories")');
+    await expect(connectRepoButton).toBeVisible();
+    await expect(connectRepoButton).toHaveAttribute("href", /\/settings\/repositories$/);
+  });
+
+  test("handles GitHub connection errors gracefully", async ({ page }) => {
+    await page.goto("/onboarding/welcome");
+    
+    // Navigate to last slide
+    await page.click('button:has-text("Next")');
+    await page.click('button:has-text("Next")');
+    
+    // Mock the GitHub App installation API to fail
+    await page.route("/api/github/install", async (route) => {
+      await route.fulfill({
+        status: 500,
+        contentType: "application/json",
+        body: JSON.stringify({
+          error: "Failed to initiate GitHub connection",
+        }),
+      });
+    });
+    
+    // Click Connect with GitHub
+    await page.click('button:has-text("Connect with GitHub")');
+    
+    // Should redirect to dashboard on error
+    await expect(page).toHaveURL(/\/([\w-]+\/)?issues$/);
+  });
+});

--- a/src/app/api/github/install/callback/__tests__/route.test.ts
+++ b/src/app/api/github/install/callback/__tests__/route.test.ts
@@ -1,0 +1,240 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { GET } from "../route";
+import { NextRequest } from "next/server";
+import { createClient } from "@/lib/supabase/server";
+
+// Mock dependencies
+vi.mock("@/lib/supabase/server", () => ({
+  createClient: vi.fn(),
+}));
+
+vi.mock("@/lib/github-app/config", () => ({
+  getGitHubAppConfig: vi.fn(() => ({
+    clientId: "test-client-id",
+    clientSecret: "test-client-secret",
+  })),
+}));
+
+vi.mock("next/server", () => ({
+  NextRequest: vi.fn(),
+  NextResponse: {
+    redirect: vi.fn((url) => ({ type: "redirect", url: url.toString() })),
+  },
+}));
+
+// Mock fetch
+global.fetch = vi.fn();
+
+describe("GitHub Install Callback Route", () => {
+  const mockSupabase = {
+    auth: {
+      getUser: vi.fn(),
+    },
+    from: vi.fn(),
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    (createClient as any).mockResolvedValue(mockSupabase);
+  });
+
+  it("redirects to workspace issues page on successful installation", async () => {
+    const mockRequest = {
+      nextUrl: {
+        searchParams: new URLSearchParams({
+          installation_id: "12345",
+          code: "test-code",
+          state: "workspace-123:csrf-token",
+        }),
+      },
+      url: "http://localhost:3000/api/github/install/callback",
+    } as unknown as NextRequest;
+
+    // Mock user authentication
+    mockSupabase.auth.getUser.mockResolvedValue({
+      data: { user: { id: "user-123" } },
+      error: null,
+    });
+
+    // Mock workspace membership check
+    const mockFrom = vi.fn(() => ({
+      select: vi.fn(() => ({
+        eq: vi.fn(() => ({
+          eq: vi.fn(() => ({
+            single: vi.fn(() => ({
+              data: { workspace_id: "workspace-123" },
+              error: null,
+            })),
+          })),
+        })),
+      })),
+    }));
+    mockSupabase.from.mockImplementation(mockFrom);
+
+    // Mock GitHub token exchange
+    (global.fetch as any)
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ access_token: "test-access-token" }),
+      })
+      // Mock GitHub installation details
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          account: {
+            login: "test-org",
+            type: "Organization",
+          },
+        }),
+      });
+
+    // Mock upsert for GitHub installation
+    mockSupabase.from.mockImplementationOnce(() => ({
+      upsert: vi.fn(() => ({
+        error: null,
+      })),
+    }));
+
+    // Mock workspace slug lookup
+    mockSupabase.from.mockImplementationOnce(() => ({
+      select: vi.fn(() => ({
+        eq: vi.fn(() => ({
+          single: vi.fn(() => ({
+            data: { slug: "test-workspace" },
+            error: null,
+          })),
+        })),
+      })),
+    }));
+
+    const response = await GET(mockRequest);
+
+    expect(response).toEqual({
+      type: "redirect",
+      url: "http://localhost:3000/test-workspace/issues",
+    });
+  });
+
+  it("redirects with error when parameters are missing", async () => {
+    const mockRequest = {
+      nextUrl: {
+        searchParams: new URLSearchParams({
+          installation_id: "12345",
+          // Missing code and state
+        }),
+      },
+      url: "http://localhost:3000/api/github/install/callback",
+    } as unknown as NextRequest;
+
+    const response = await GET(mockRequest);
+
+    expect(response.url).toContain("/?error=missing_params");
+  });
+
+  it("redirects to workspace-specific error page when available", async () => {
+    const mockRequest = {
+      nextUrl: {
+        searchParams: new URLSearchParams({
+          installation_id: "12345",
+          code: "test-code",
+          state: "workspace-123:csrf-token",
+        }),
+      },
+      url: "http://localhost:3000/api/github/install/callback",
+    } as unknown as NextRequest;
+
+    // Mock user authentication
+    mockSupabase.auth.getUser.mockResolvedValue({
+      data: { user: { id: "user-123" } },
+      error: null,
+    });
+
+    // Mock workspace membership check - user not a member
+    mockSupabase.from.mockImplementationOnce(() => ({
+      select: vi.fn(() => ({
+        eq: vi.fn(() => ({
+          eq: vi.fn(() => ({
+            single: vi.fn(() => ({
+              data: null,
+              error: { code: "PGRST116" },
+            })),
+          })),
+        })),
+      })),
+    }));
+
+    // Mock workspace slug lookup
+    mockSupabase.from.mockImplementationOnce(() => ({
+      select: vi.fn(() => ({
+        eq: vi.fn(() => ({
+          single: vi.fn(() => ({
+            data: { slug: "test-workspace" },
+            error: null,
+          })),
+        })),
+      })),
+    }));
+
+    const response = await GET(mockRequest);
+
+    expect(response).toEqual({
+      type: "redirect",
+      url: "http://localhost:3000/test-workspace/settings/github?error=invalid_workspace",
+    });
+  });
+
+  it("handles GitHub token exchange failure", async () => {
+    const mockRequest = {
+      nextUrl: {
+        searchParams: new URLSearchParams({
+          installation_id: "12345",
+          code: "test-code",
+          state: "workspace-123:csrf-token",
+        }),
+      },
+      url: "http://localhost:3000/api/github/install/callback",
+    } as unknown as NextRequest;
+
+    // Mock user authentication
+    mockSupabase.auth.getUser.mockResolvedValue({
+      data: { user: { id: "user-123" } },
+      error: null,
+    });
+
+    // Mock workspace membership check
+    mockSupabase.from.mockImplementationOnce(() => ({
+      select: vi.fn(() => ({
+        eq: vi.fn(() => ({
+          eq: vi.fn(() => ({
+            single: vi.fn(() => ({
+              data: { workspace_id: "workspace-123" },
+              error: null,
+            })),
+          })),
+        })),
+      })),
+    }));
+
+    // Mock failed GitHub token exchange
+    (global.fetch as any).mockResolvedValueOnce({
+      ok: false,
+      text: async () => "Token exchange failed",
+    });
+
+    // Mock workspace slug lookup
+    mockSupabase.from.mockImplementationOnce(() => ({
+      select: vi.fn(() => ({
+        eq: vi.fn(() => ({
+          single: vi.fn(() => ({
+            data: { slug: "test-workspace" },
+            error: null,
+          })),
+        })),
+      })),
+    }));
+
+    const response = await GET(mockRequest);
+
+    expect(response.url).toContain("/test-workspace/settings/github?error=token_exchange_failed");
+  });
+});

--- a/src/app/api/github/install/callback/route.ts
+++ b/src/app/api/github/install/callback/route.ts
@@ -9,8 +9,31 @@ export async function GET(request: NextRequest) {
   const state = searchParams.get("state");
 
   if (!installationId || !code || !state) {
+    // Try to get workspace from state for proper redirect
+    if (state) {
+      const [workspaceId] = state.split(":");
+      if (workspaceId) {
+        try {
+          const supabase = await createClient();
+          const { data: workspace } = await supabase
+            .from("workspaces")
+            .select("slug")
+            .eq("id", workspaceId)
+            .single();
+          
+          if (workspace) {
+            return NextResponse.redirect(
+              new URL(`/${workspace.slug}/settings/github?error=missing_params`, request.url)
+            );
+          }
+        } catch {
+          // Fall through to default redirect
+        }
+      }
+    }
+    
     return NextResponse.redirect(
-      new URL("/settings/github?error=missing_params", request.url)
+      new URL("/?error=missing_params", request.url)
     );
   }
 
@@ -35,8 +58,21 @@ export async function GET(request: NextRequest) {
       .single();
 
     if (!sessionData) {
+      // Try to get workspace for proper redirect
+      const { data: workspace } = await supabase
+        .from("workspaces")
+        .select("slug")
+        .eq("id", workspaceId)
+        .single();
+      
+      if (workspace) {
+        return NextResponse.redirect(
+          new URL(`/${workspace.slug}/settings/github?error=invalid_workspace`, request.url)
+        );
+      }
+      
       return NextResponse.redirect(
-        new URL("/settings/github?error=invalid_workspace", request.url)
+        new URL("/?error=invalid_workspace", request.url)
       );
     }
 
@@ -60,8 +96,14 @@ export async function GET(request: NextRequest) {
 
     if (!tokenResponse.ok) {
       console.error("Failed to exchange code for token:", await tokenResponse.text());
+      const { data: workspace } = await supabase
+        .from("workspaces")
+        .select("slug")
+        .eq("id", workspaceId)
+        .single();
+      
       return NextResponse.redirect(
-        new URL("/settings/github?error=token_exchange_failed", request.url)
+        new URL(workspace ? `/${workspace.slug}/settings/github?error=token_exchange_failed` : "/?error=token_exchange_failed", request.url)
       );
     }
 
@@ -70,8 +112,14 @@ export async function GET(request: NextRequest) {
 
     if (!accessToken) {
       console.error("No access token in response:", tokenData);
+      const { data: workspace } = await supabase
+        .from("workspaces")
+        .select("slug")
+        .eq("id", workspaceId)
+        .single();
+      
       return NextResponse.redirect(
-        new URL("/settings/github?error=no_access_token", request.url)
+        new URL(workspace ? `/${workspace.slug}/settings/github?error=no_access_token` : "/?error=no_access_token", request.url)
       );
     }
 
@@ -88,8 +136,14 @@ export async function GET(request: NextRequest) {
 
     if (!installationResponse.ok) {
       console.error("Failed to get installation details:", await installationResponse.text());
+      const { data: workspace } = await supabase
+        .from("workspaces")
+        .select("slug")
+        .eq("id", workspaceId)
+        .single();
+      
       return NextResponse.redirect(
-        new URL("/settings/github?error=installation_fetch_failed", request.url)
+        new URL(workspace ? `/${workspace.slug}/settings/github?error=installation_fetch_failed` : "/?error=installation_fetch_failed", request.url)
       );
     }
 
@@ -111,19 +165,64 @@ export async function GET(request: NextRequest) {
 
     if (insertError) {
       console.error("Failed to store installation:", insertError);
+      const { data: workspace } = await supabase
+        .from("workspaces")
+        .select("slug")
+        .eq("id", workspaceId)
+        .single();
+      
       return NextResponse.redirect(
-        new URL("/settings/github?error=storage_failed", request.url)
+        new URL(workspace ? `/${workspace.slug}/settings/github?error=storage_failed` : "/?error=storage_failed", request.url)
       );
     }
 
-    // Redirect to settings page with success
+    // Get workspace details for slug
+    const { data: workspace } = await supabase
+      .from("workspaces")
+      .select("slug")
+      .eq("id", workspaceId)
+      .single();
+
+    if (!workspace) {
+      return NextResponse.redirect(
+        new URL("/?error=workspace_not_found", request.url)
+      );
+    }
+
+    // Redirect to workspace-specific issues page
     return NextResponse.redirect(
-      new URL("/settings/github?success=true", request.url)
+      new URL(`/${workspace.slug}/issues`, request.url)
     );
   } catch (error) {
     console.error("GitHub App installation callback error:", error);
+    // Get workspace for error redirect
+    try {
+      const supabase = await createClient();
+      const { data: { user } } = await supabase.auth.getUser();
+      
+      if (user) {
+        const { data: workspaces } = await supabase
+          .from("workspace_members")
+          .select("workspace:workspaces(slug)")
+          .eq("user_id", user.id)
+          .order("created_at", { ascending: false })
+          .limit(1);
+        
+        if (workspaces && workspaces.length > 0) {
+          const workspaceRecord = workspaces[0];
+          if ('workspace' in workspaceRecord && workspaceRecord.workspace && 'slug' in workspaceRecord.workspace) {
+            return NextResponse.redirect(
+              new URL(`/${workspaceRecord.workspace.slug}/settings/github?error=unexpected`, request.url)
+            );
+          }
+        }
+      }
+    } catch {
+      // Fallback to root if we can't get workspace
+    }
+    
     return NextResponse.redirect(
-      new URL("/settings/github?error=unexpected", request.url)
+      new URL("/?error=github_connect_failed", request.url)
     );
   }
 }

--- a/src/app/onboarding/welcome/__tests__/page.test.tsx
+++ b/src/app/onboarding/welcome/__tests__/page.test.tsx
@@ -1,0 +1,179 @@
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { vi, describe, it, expect, beforeEach } from "vitest";
+import WelcomePage from "../page";
+import { useRouter } from "next/navigation";
+import { useWorkspaceStore } from "@/stores/workspace.store";
+
+// Mock dependencies
+vi.mock("next/navigation", () => ({
+  useRouter: vi.fn(),
+}));
+
+vi.mock("@/stores/workspace.store", () => ({
+  useWorkspaceStore: vi.fn(),
+}));
+
+vi.mock("@/lib/supabase/client", () => ({
+  createClient: vi.fn(() => ({
+    auth: {
+      getUser: vi.fn().mockResolvedValue({
+        data: { user: { id: "test-user-id" } },
+      }),
+    },
+    from: vi.fn(() => ({
+      select: vi.fn(() => ({
+        eq: vi.fn(() => ({
+          order: vi.fn(() => ({
+            limit: vi.fn().mockResolvedValue({
+              data: [{ workspace: { id: "test-workspace-id", slug: "test-workspace" } }],
+            }),
+          })),
+        })),
+      })),
+    })),
+  })),
+}));
+
+// Mock fetch
+global.fetch = vi.fn();
+
+describe("WelcomePage", () => {
+  const mockPush = vi.fn();
+  const mockLoadWorkspaces = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    (useRouter as any).mockReturnValue({ push: mockPush });
+    (useWorkspaceStore as any).mockReturnValue({
+      currentWorkspace: { id: "test-workspace-id", slug: "test-workspace" },
+      loadWorkspaces: mockLoadWorkspaces,
+    });
+  });
+
+  it("renders the first slide correctly", () => {
+    render(<WelcomePage />);
+    
+    expect(screen.getByText("Welcome to Daygent")).toBeInTheDocument();
+    expect(screen.getByText(/Daygent is an app to manage Software Engineering Agents/)).toBeInTheDocument();
+    expect(screen.getByText("Next")).toBeInTheDocument();
+  });
+
+  it("navigates through slides when clicking next", () => {
+    render(<WelcomePage />);
+    
+    const nextButton = screen.getByRole("button", { name: /next/i });
+    
+    // Click to second slide
+    fireEvent.click(nextButton);
+    expect(screen.getByText("AI-Powered Development")).toBeInTheDocument();
+    
+    // Click to third slide
+    fireEvent.click(nextButton);
+    expect(screen.getByText("GitHub Integration")).toBeInTheDocument();
+    expect(screen.getByText("Connect with GitHub")).toBeInTheDocument();
+  });
+
+  it("initiates GitHub App installation on final slide", async () => {
+    (global.fetch as any).mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ install_url: "https://github.com/apps/test-app/installations/new" }),
+    });
+
+    // Mock window.location
+    delete (window as any).location;
+    window.location = { href: "" } as any;
+
+    render(<WelcomePage />);
+    
+    // Navigate to last slide
+    const nextButton = screen.getByRole("button", { name: /next/i });
+    fireEvent.click(nextButton);
+    fireEvent.click(nextButton);
+    
+    // Click Connect with GitHub
+    const connectButton = screen.getByRole("button", { name: /connect with github/i });
+    fireEvent.click(connectButton);
+
+    // Should show loading state
+    expect(screen.getByText("Connecting...")).toBeInTheDocument();
+
+    await waitFor(() => {
+      expect(global.fetch).toHaveBeenCalledWith("/api/github/install", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          workspace_id: "test-workspace-id",
+        }),
+      });
+    });
+
+    await waitFor(() => {
+      expect(window.location.href).toBe("https://github.com/apps/test-app/installations/new");
+    });
+  });
+
+  it("redirects to workspace creation if no workspace found", async () => {
+    (useWorkspaceStore as any).mockReturnValue({
+      currentWorkspace: null,
+      loadWorkspaces: mockLoadWorkspaces,
+    });
+
+    // Mock supabase to return no workspaces
+    vi.mock("@/lib/supabase/client", () => ({
+      createClient: vi.fn(() => ({
+        auth: {
+          getUser: vi.fn().mockResolvedValue({
+            data: { user: { id: "test-user-id" } },
+          }),
+        },
+        from: vi.fn(() => ({
+          select: vi.fn(() => ({
+            eq: vi.fn(() => ({
+              order: vi.fn(() => ({
+                limit: vi.fn().mockResolvedValue({
+                  data: [],
+                }),
+              })),
+            })),
+          })),
+        })),
+      })),
+    }));
+
+    render(<WelcomePage />);
+    
+    // Navigate to last slide
+    const nextButton = screen.getByRole("button", { name: /next/i });
+    fireEvent.click(nextButton);
+    fireEvent.click(nextButton);
+    
+    // Click Connect with GitHub
+    const connectButton = screen.getByRole("button", { name: /connect with github/i });
+    fireEvent.click(connectButton);
+
+    await waitFor(() => {
+      expect(mockPush).toHaveBeenCalledWith("/onboarding/workspace");
+    });
+  });
+
+  it("handles GitHub connection errors gracefully", async () => {
+    (global.fetch as any).mockRejectedValueOnce(new Error("Connection failed"));
+
+    render(<WelcomePage />);
+    
+    // Navigate to last slide
+    const nextButton = screen.getByRole("button", { name: /next/i });
+    fireEvent.click(nextButton);
+    fireEvent.click(nextButton);
+    
+    // Click Connect with GitHub
+    const connectButton = screen.getByRole("button", { name: /connect with github/i });
+    fireEvent.click(connectButton);
+
+    await waitFor(() => {
+      expect(mockPush).toHaveBeenCalledWith("/test-workspace/issues");
+    });
+  });
+});

--- a/src/app/onboarding/welcome/page.tsx
+++ b/src/app/onboarding/welcome/page.tsx
@@ -56,17 +56,27 @@ export default function WelcomePage() {
           const { data: { user } } = await supabase.auth.getUser();
           
           if (user) {
-            const { data: workspaces } = await supabase
+            const { data: memberRecords } = await supabase
               .from("workspace_members")
-              .select("workspace:workspaces(*)")
+              .select(`
+                workspace_id,
+                workspaces (
+                  id,
+                  name,
+                  slug,
+                  created_by,
+                  created_at,
+                  updated_at
+                )
+              `)
               .eq("user_id", user.id)
               .order("created_at", { ascending: false })
               .limit(1);
             
-            if (workspaces && workspaces.length > 0) {
-              const workspaceRecord = workspaces[0];
-              if ('workspace' in workspaceRecord && workspaceRecord.workspace && typeof workspaceRecord.workspace === 'object' && 'id' in workspaceRecord.workspace) {
-                workspace = workspaceRecord.workspace as Workspace;
+            if (memberRecords && memberRecords.length > 0) {
+              const record = memberRecords[0];
+              if (record.workspaces) {
+                workspace = record.workspaces as unknown as Workspace;
               }
             }
           }

--- a/src/app/onboarding/welcome/page.tsx
+++ b/src/app/onboarding/welcome/page.tsx
@@ -7,6 +7,9 @@ import { Card } from "@/components/ui/card";
 import { ChevronRight, Code, GitBranch, Zap, Loader2 } from "lucide-react";
 import { createClient } from "@/lib/supabase/client";
 import { useWorkspaceStore } from "@/stores/workspace.store";
+import type { Database } from "@/lib/database.types";
+
+type Workspace = Database["public"]["Tables"]["workspaces"]["Row"];
 
 const slides = [
   {
@@ -63,7 +66,7 @@ export default function WelcomePage() {
             if (workspaces && workspaces.length > 0) {
               const workspaceRecord = workspaces[0];
               if ('workspace' in workspaceRecord && workspaceRecord.workspace && typeof workspaceRecord.workspace === 'object' && 'id' in workspaceRecord.workspace) {
-                workspace = workspaceRecord.workspace as any;
+                workspace = workspaceRecord.workspace as Workspace;
               }
             }
           }

--- a/src/app/onboarding/welcome/page.tsx
+++ b/src/app/onboarding/welcome/page.tsx
@@ -63,7 +63,7 @@ export default function WelcomePage() {
             if (workspaces && workspaces.length > 0) {
               const workspaceRecord = workspaces[0];
               if ('workspace' in workspaceRecord && workspaceRecord.workspace && typeof workspaceRecord.workspace === 'object' && 'id' in workspaceRecord.workspace) {
-                workspace = workspaceRecord.workspace as typeof workspace;
+                workspace = workspaceRecord.workspace as any;
               }
             }
           }


### PR DESCRIPTION
## Summary
- Fixed redirect flow after clicking "Connect with GitHub" in onboarding slides
- Implemented proper GitHub App installation flow from welcome page
- Updated callback to redirect users to workspace issues page after authorization
- Fixed TypeScript and ESLint errors that were preventing Vercel deployment

## Changes Made
1. **Welcome Page Updates** (`src/app/onboarding/welcome/page.tsx`):
   - Added direct GitHub App installation initiation
   - Fetches current workspace before redirecting
   - Shows loading state during connection process
   - Handles errors gracefully with fallback redirects
   - Fixed TypeScript type assertions to avoid build errors
   - Updated workspace query to match store pattern

2. **GitHub Callback Updates** (`src/app/api/github/install/callback/route.ts`):
   - Fixed redirect URLs to include workspace slug
   - Redirects to workspace issues page after successful installation
   - Better error handling with workspace-specific redirects

3. **Tests Added**:
   - Unit tests for welcome page flow
   - API route tests for GitHub callback
   - E2E tests for complete onboarding flow

4. **Build Fixes**:
   - Resolved TypeScript compilation error with workspace type casting
   - Fixed ESLint no-explicit-any violation by using proper Workspace type
   - Updated query pattern to match workspace store implementation

## Expected Behavior
1. User creates workspace
2. Goes through welcome slides  
3. Clicks "Connect with GitHub" on final slide
4. Gets redirected to GitHub App installation page
5. After authorization, lands on workspace issues page
6. Empty state shows "Import Issues from GitHub" buttons

## Test Plan
- [x] Unit tests pass
- [x] E2E tests cover the flow
- [x] TypeScript compilation succeeds
- [x] ESLint checks pass
- [ ] Manual testing of complete flow
- [ ] Verify GitHub App installation works
- [ ] Confirm redirect to issues page
- [ ] Test error scenarios

🤖 Generated with [Claude Code](https://claude.ai/code)