### PR TITLE
Fix: Remove client-side redirect in auth callback to fix onboarding flow

### DIFF
--- a/src/app/auth/callback/page.tsx
+++ b/src/app/auth/callback/page.tsx
@@ -11,14 +11,12 @@ function AuthCallbackContent() {
   const code = searchParams.get("code");
 
   useEffect(() => {
-    if (code) {
-      // The auth has already been handled by the API route,
-      // we just need to redirect to the dashboard
-      router.push("/dashboard");
-    } else {
+    if (!code) {
       // No code, something went wrong
       router.push("/login?error=auth_callback_error");
     }
+    // If we have a code, the server-side route handler will handle the redirect
+    // We don't need to do anything here - just show the loading state
   }, [code, router]);
 
   return (


### PR DESCRIPTION
## Summary
- Fixed the onboarding flow by removing conflicting client-side redirect logic in the auth callback page
- New users now properly go through the profile setup step before workspace creation

## Problem
The authentication flow had competing redirect mechanisms:
- **Server-side** (`/api/auth/callback/route.ts`): Correctly checks if users need profile setup
- **Client-side** (`/auth/callback/page.tsx`): Was overriding with a hardcoded redirect to `/dashboard`

This caused new users to skip the profile setup step and go directly to workspace creation.

## Solution
Modified the client-side callback page to only show a loading state and let the server-side route handle all redirect logic based on user state:
- New users without profile → `/onboarding/profile`
- Users with profile but no workspace → `/onboarding/workspace`
- Users with workspace → `/{workspace}/issues`

## Test plan
- [x] Clear browser cache/cookies
- [x] Delete all user data from Supabase
- [x] Sign in with GitHub as a new user
- [x] Verify redirect to `/onboarding/profile` (not directly to workspace creation)
- [x] Complete profile setup
- [x] Verify redirect to `/onboarding/workspace`
- [x] Create workspace and complete onboarding

🤖 Generated with [Claude Code](https://claude.ai/code)