### PR TITLE
fix: remove unnecessary Suspense wrapper causing infinite loading spinner

### DIFF
--- a/src/app/[workspace]/(dashboard)/issues/page.tsx
+++ b/src/app/[workspace]/(dashboard)/issues/page.tsx
@@ -1,4 +1,3 @@
-import { Suspense } from "react";
 import { createClient } from "@/lib/supabase/server";
 import { IssueList } from "./components/IssueList";
 import { IssueFilters } from "./components/IssueFilters";
@@ -161,14 +160,12 @@ export default async function IssuesPage({
             <IssueSorting />
           </div>
 
-          <Suspense fallback={<div>Loading issues...</div>}>
-            <IssueList
-              issues={issues || []}
-              totalCount={count || 0}
-              currentPage={page}
-              totalPages={totalPages}
-            />
-          </Suspense>
+          <IssueList
+            issues={issues || []}
+            totalCount={count || 0}
+            currentPage={page}
+            totalPages={totalPages}
+          />
         </>
       )}
     </div>


### PR DESCRIPTION
## Summary
- Removed the Suspense wrapper from the issues page that was causing an infinite loading state
- The issues page already loads data server-side, so Suspense is unnecessary

## Problem
When no repositories are connected to the workspace, the issues page displays an infinite loading spinner instead of showing the empty state message.

## Solution
The root cause was an unnecessary `<Suspense>` wrapper around the `<IssueList>` component. Since the issues page already fetches data server-side in an async Server Component, the Suspense boundary serves no purpose and was preventing the proper rendering of the empty state.

## Test plan
- [x] Navigate to issues page with no connected repositories
- [x] Verify empty state message displays correctly
- [x] Connect a repository and verify issues load properly
- [x] Test pagination still works correctly

🤖 Generated with [Claude Code](https://claude.ai/code)