### PR TITLE
fix: remove Repositories menu item from sidebar

### DIFF
--- a/src/components/layout/__tests__/SidebarNav.test.tsx
+++ b/src/components/layout/__tests__/SidebarNav.test.tsx
@@ -11,7 +11,6 @@ describe("SidebarNav", () => {
     render(<SidebarNav isOpen={true} pathname="/issues" />);
 
     expect(screen.getByText("Issues")).toBeInTheDocument();
-    expect(screen.getByText("Repositories")).toBeInTheDocument();
     expect(screen.getByText("Settings")).toBeInTheDocument();
   });
 
@@ -19,12 +18,12 @@ describe("SidebarNav", () => {
     render(<SidebarNav isOpen={true} pathname="/issues" />);
 
     const issuesLink = screen.getByRole("link", { name: /issues/i });
-    const repositoriesLink = screen.getByRole("link", {
-      name: /repositories/i,
+    const settingsLink = screen.getByRole("link", {
+      name: /settings/i,
     });
 
     expect(issuesLink).toHaveClass("bg-accent");
-    expect(repositoriesLink).not.toHaveClass("bg-accent");
+    expect(settingsLink).not.toHaveClass("bg-accent");
   });
 
   it("hides text when sidebar is collapsed", () => {
@@ -38,13 +37,9 @@ describe("SidebarNav", () => {
     render(<SidebarNav isOpen={true} pathname="/issues" />);
 
     const issuesLink = screen.getByRole("link", { name: /issues/i });
-    const repositoriesLink = screen.getByRole("link", {
-      name: /repositories/i,
-    });
     const settingsLink = screen.getByRole("link", { name: /settings/i });
 
     expect(issuesLink).toHaveAttribute("href", "/issues");
-    expect(repositoriesLink).toHaveAttribute("href", "/repositories");
     expect(settingsLink).toHaveAttribute("href", "/settings");
   });
 

--- a/src/lib/navigation.ts
+++ b/src/lib/navigation.ts
@@ -1,6 +1,5 @@
 import {
   ListTodo,
-  GitBranch,
   Settings,
 } from "lucide-react";
 
@@ -9,11 +8,6 @@ export const NAV_ITEMS = [
     title: "Issues",
     href: "/issues",
     icon: ListTodo,
-  },
-  {
-    title: "Repositories",
-    href: "/repositories",
-    icon: GitBranch,
   },
   {
     title: "Settings",


### PR DESCRIPTION
## Summary
- Removed the "Repositories" menu item from the sidebar navigation
- Updated tests to reflect the navigation changes
- Simplified the main navigation to only show Issues and Settings

## Test plan
- [x] Verified the Repositories menu item no longer appears in the sidebar
- [x] All SidebarNav tests pass successfully
- [x] ESLint passes without warnings or errors
- [x] The navigation still functions correctly with Issues and Settings

🤖 Generated with [Claude Code](https://claude.ai/code)