### PR TITLE
feat: add workspace name to top of sidebar

### DIFF
--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -11,6 +11,7 @@ import {
 import { cn } from "@/lib/utils";
 import { SidebarNav } from "./SidebarNav";
 import { UserMenu } from "./UserMenu";
+import { useWorkspaceStore } from "@/stores/workspace.store";
 
 interface SidebarProps {
   isOpen: boolean;
@@ -19,6 +20,8 @@ interface SidebarProps {
 }
 
 export function Sidebar({ isOpen, onToggle, pathname }: SidebarProps) {
+  const { currentWorkspace } = useWorkspaceStore();
+
   return (
     <aside
       className={cn(
@@ -27,6 +30,18 @@ export function Sidebar({ isOpen, onToggle, pathname }: SidebarProps) {
       )}
     >
       <div className="flex h-full flex-col">
+        {/* Workspace name section */}
+        {currentWorkspace && (
+          <div className="px-4 py-3 border-b">
+            <h2 className={cn(
+              "font-semibold text-sm truncate transition-opacity duration-200",
+              !isOpen && "opacity-0"
+            )}>
+              {currentWorkspace.name}
+            </h2>
+          </div>
+        )}
+        
         <div className="flex h-12 items-center justify-between px-4 border-b">
           {/* Spacer to keep toggle button on the right */}
           <div className="flex-1" />

--- a/src/components/layout/__tests__/Sidebar.test.tsx
+++ b/src/components/layout/__tests__/Sidebar.test.tsx
@@ -1,0 +1,117 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { Sidebar } from "../Sidebar";
+import { useWorkspaceStore } from "@/stores/workspace.store";
+
+// Mock the workspace store
+vi.mock("@/stores/workspace.store", () => ({
+  useWorkspaceStore: vi.fn(),
+}));
+
+// Mock the auth store (used by UserMenu)
+vi.mock("@/stores/auth.store", () => ({
+  useAuthStore: () => ({
+    user: {
+      id: "1",
+      email: "test@example.com",
+      user_metadata: { full_name: "Test User" },
+    },
+    logout: vi.fn(),
+  }),
+}));
+
+// Mock next/navigation
+vi.mock("next/navigation", () => ({
+  usePathname: () => "/issues",
+  useRouter: () => ({
+    push: vi.fn(),
+    back: vi.fn(),
+    forward: vi.fn(),
+    refresh: vi.fn(),
+    replace: vi.fn(),
+    prefetch: vi.fn(),
+  }),
+}));
+
+describe("Sidebar", () => {
+  const mockToggle = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("displays workspace name when workspace is available and sidebar is open", () => {
+    (useWorkspaceStore as any).mockReturnValue({
+      currentWorkspace: {
+        id: "1",
+        name: "Test Workspace",
+        slug: "test-workspace",
+      },
+    });
+
+    render(<Sidebar isOpen={true} onToggle={mockToggle} pathname="/issues" />);
+
+    expect(screen.getByText("Test Workspace")).toBeInTheDocument();
+  });
+
+  it("hides workspace name when sidebar is collapsed", () => {
+    (useWorkspaceStore as any).mockReturnValue({
+      currentWorkspace: {
+        id: "1",
+        name: "Test Workspace",
+        slug: "test-workspace",
+      },
+    });
+
+    render(<Sidebar isOpen={false} onToggle={mockToggle} pathname="/issues" />);
+
+    const workspaceName = screen.getByText("Test Workspace");
+    expect(workspaceName).toHaveClass("opacity-0");
+  });
+
+  it("does not display workspace section when no workspace is available", () => {
+    (useWorkspaceStore as any).mockReturnValue({
+      currentWorkspace: null,
+    });
+
+    render(<Sidebar isOpen={true} onToggle={mockToggle} pathname="/issues" />);
+
+    expect(screen.queryByText("Test Workspace")).not.toBeInTheDocument();
+  });
+
+  it("renders navigation and user menu sections", () => {
+    (useWorkspaceStore as any).mockReturnValue({
+      currentWorkspace: {
+        id: "1",
+        name: "Test Workspace",
+        slug: "test-workspace",
+      },
+    });
+
+    render(<Sidebar isOpen={true} onToggle={mockToggle} pathname="/issues" />);
+
+    // Check for navigation items
+    expect(screen.getByText("Issues")).toBeInTheDocument();
+    expect(screen.getByText("Settings")).toBeInTheDocument();
+  });
+
+  it("displays toggle button with correct aria-label", () => {
+    (useWorkspaceStore as any).mockReturnValue({
+      currentWorkspace: null,
+    });
+
+    const { rerender } = render(
+      <Sidebar isOpen={true} onToggle={mockToggle} pathname="/issues" />
+    );
+
+    expect(
+      screen.getByRole("button", { name: "Collapse sidebar" })
+    ).toBeInTheDocument();
+
+    rerender(<Sidebar isOpen={false} onToggle={mockToggle} pathname="/issues" />);
+
+    expect(
+      screen.getByRole("button", { name: "Expand sidebar" })
+    ).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary
- Added the current workspace name display at the top of the sidebar
- Workspace name is hidden when sidebar is collapsed (using opacity-0 for smooth transitions)
- Only displays the workspace section when a workspace is available
- Added comprehensive test coverage for the Sidebar component

## Changes
- Modified `Sidebar.tsx` to include workspace name section
- Added `useWorkspaceStore` to access current workspace data
- Created new test file `Sidebar.test.tsx` with 5 test cases covering all scenarios

## Test plan
- [x] Workspace name displays correctly when sidebar is open
- [x] Workspace name hides (opacity-0) when sidebar is collapsed
- [x] No workspace section shown when no workspace is available
- [x] All existing navigation and toggle functionality preserved
- [x] Tests pass with proper mocking of dependencies
- [x] ESLint passes without warnings

🤖 Generated with [Claude Code](https://claude.ai/code)