### PR TITLE
fix: always display workspace section with fallback text

### DIFF
--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -31,16 +31,14 @@ export function Sidebar({ isOpen, onToggle, pathname }: SidebarProps) {
     >
       <div className="flex h-full flex-col">
         {/* Workspace name section */}
-        {currentWorkspace && (
-          <div className="px-4 py-3 border-b">
-            <h2 className={cn(
-              "font-semibold text-sm truncate transition-opacity duration-200",
-              !isOpen && "opacity-0"
-            )}>
-              {currentWorkspace.name}
-            </h2>
-          </div>
-        )}
+        <div className="px-4 py-3 border-b">
+          <h2 className={cn(
+            "font-semibold text-sm truncate transition-opacity duration-200",
+            !isOpen && "opacity-0"
+          )}>
+            {currentWorkspace ? currentWorkspace.name : "No Workspace Selected"}
+          </h2>
+        </div>
         
         <div className="flex h-12 items-center justify-between px-4 border-b">
           {/* Spacer to keep toggle button on the right */}

--- a/src/components/layout/__tests__/Sidebar.test.tsx
+++ b/src/components/layout/__tests__/Sidebar.test.tsx
@@ -69,14 +69,26 @@ describe("Sidebar", () => {
     expect(workspaceName).toHaveClass("opacity-0");
   });
 
-  it("does not display workspace section when no workspace is available", () => {
+  it("displays 'No Workspace Selected' when no workspace is available", () => {
     (useWorkspaceStore as any).mockReturnValue({
       currentWorkspace: null,
     });
 
     render(<Sidebar isOpen={true} onToggle={mockToggle} pathname="/issues" />);
 
+    expect(screen.getByText("No Workspace Selected")).toBeInTheDocument();
     expect(screen.queryByText("Test Workspace")).not.toBeInTheDocument();
+  });
+
+  it("hides 'No Workspace Selected' text when sidebar is collapsed", () => {
+    (useWorkspaceStore as any).mockReturnValue({
+      currentWorkspace: null,
+    });
+
+    render(<Sidebar isOpen={false} onToggle={mockToggle} pathname="/issues" />);
+
+    const noWorkspaceText = screen.getByText("No Workspace Selected");
+    expect(noWorkspaceText).toHaveClass("opacity-0");
   });
 
   it("renders navigation and user menu sections", () => {


### PR DESCRIPTION
## Summary
Fixes the workspace name display in sidebar to always show the workspace section with appropriate fallback text.

## Problem  
The previous implementation only showed the workspace section when a workspace was available, but the requirement was to always show it with "No Workspace Selected" when no workspace is present.

## Changes
- **Always display workspace section** (removed conditional rendering)
- **Show workspace name** when a workspace is available  
- **Show "No Workspace Selected"** when no workspace is selected
- **Maintain opacity behavior** - both texts hide when sidebar is collapsed
- **Updated tests** to cover the new fallback behavior

## Test Plan
- [x] Workspace name displays when workspace is available
- [x] "No Workspace Selected" displays when no workspace 
- [x] Both texts hide (opacity-0) when sidebar is collapsed
- [x] All existing functionality preserved
- [x] Tests pass with 6/6 test cases
- [x] ESLint passes without warnings

This ensures users always see workspace context in the sidebar, even when no workspace is selected.

🤖 Generated with [Claude Code](https://claude.ai/code)