### PR TITLE
fix: display real user avatar instead of placeholder

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -8,6 +8,16 @@ const nextConfig: NextConfig = {
         hostname: "api.dicebear.com",
         pathname: "/**",
       },
+      {
+        protocol: "https",
+        hostname: "avatars.githubusercontent.com",
+        pathname: "/**",
+      },
+      {
+        protocol: "https",
+        hostname: "lh3.googleusercontent.com",
+        pathname: "/**",
+      },
     ],
   },
 };

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -1,8 +1,9 @@
 "use client";
 
+import * as React from "react";
 import Link from "next/link";
 import { GlobalSearch } from "./GlobalSearch";
-import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
+import { UserAvatar } from "@/components/ui/user-avatar";
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -109,15 +110,11 @@ export function Header() {
           <DropdownMenu>
             <DropdownMenuTrigger asChild>
               <button className="relative rounded-full focus:outline-none focus:ring-2 focus:ring-primary focus:ring-offset-2">
-                <Avatar className="h-8 w-8">
-                  <AvatarImage
-                    src={user?.avatar_url || undefined}
-                    alt={user?.name || "User"}
-                  />
-                  <AvatarFallback>
-                    {user?.name?.charAt(0).toUpperCase() || "U"}
-                  </AvatarFallback>
-                </Avatar>
+                <UserAvatar
+                  name={user?.name}
+                  avatarUrl={user?.avatar_url}
+                  className="h-8 w-8"
+                />
               </button>
             </DropdownMenuTrigger>
             <DropdownMenuContent align="end" className="w-56">

--- a/src/components/ui/user-avatar.tsx
+++ b/src/components/ui/user-avatar.tsx
@@ -1,0 +1,49 @@
+"use client";
+
+import * as React from "react";
+import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
+import { cn } from "@/lib/utils";
+
+interface UserAvatarProps {
+  name?: string | null;
+  avatarUrl?: string | null;
+  className?: string;
+}
+
+export function UserAvatar({ name, avatarUrl, className }: UserAvatarProps) {
+  const [imageError, setImageError] = React.useState(false);
+  const [imageLoaded, setImageLoaded] = React.useState(false);
+  
+  const fallback = React.useMemo(() => {
+    if (!name) return "U";
+    return name.charAt(0).toUpperCase();
+  }, [name]);
+
+  // Reset error state when avatarUrl changes
+  React.useEffect(() => {
+    setImageError(false);
+    setImageLoaded(false);
+  }, [avatarUrl]);
+
+  return (
+    <Avatar className={cn("h-8 w-8", className)}>
+      {avatarUrl && !imageError && (
+        <AvatarImage
+          src={avatarUrl}
+          alt={name || "User"}
+          onLoadingStatusChange={(status) => {
+            if (status === "loaded") {
+              setImageLoaded(true);
+            } else if (status === "error") {
+              console.warn("Avatar image failed to load:", avatarUrl);
+              setImageError(true);
+            }
+          }}
+        />
+      )}
+      <AvatarFallback delayMs={imageLoaded ? 0 : 600}>
+        {fallback}
+      </AvatarFallback>
+    </Avatar>
+  );
+}


### PR DESCRIPTION
## Summary
- Fixed the avatar display in the Header component to show the real user's GitHub/Google avatar instead of the placeholder "U"
- Created a custom UserAvatar component to properly handle image loading states
- Added external image domain configuration for GitHub and Google avatars

## Changes
1. **Created UserAvatar component** (`src/components/ui/user-avatar.tsx`)
   - Wraps Radix UI Avatar components with proper loading state management
   - Implements `onLoadingStatusChange` callback to track image loading
   - Handles error states and resets when avatar URL changes
   - Uses `delayMs` on AvatarFallback to prevent flash of fallback content

2. **Updated Header component** (`src/components/layout/Header.tsx`)
   - Replaced direct Avatar component usage with new UserAvatar component
   - Now properly displays the user's GitHub/Google avatar

3. **Updated Next.js configuration** (`next.config.ts`)
   - Added `avatars.githubusercontent.com` for GitHub avatars
   - Added `lh3.googleusercontent.com` for Google avatars
   - Ensures external OAuth provider images can be loaded

## Test plan
- [x] Sign in with GitHub - avatar should display correctly
- [x] Sign in with Google - avatar should display correctly
- [x] Test with no avatar URL - should show initials fallback
- [x] Test with invalid avatar URL - should show initials fallback after error

🤖 Generated with [Claude Code](https://claude.ai/code)