### PR TITLE
Fix: Sync workspace store with URL to resolve 'No Workspace Selected' issue

### DIFF
--- a/src/app/[workspace]/(dashboard)/layout.tsx
+++ b/src/app/[workspace]/(dashboard)/layout.tsx
@@ -1,9 +1,15 @@
 import { DashboardLayout } from "@/components/layout/DashboardLayout";
+import { WorkspaceSync } from "@/components/workspace-sync";
 
 export default function DashboardRouteLayout({
   children,
 }: {
   children: React.ReactNode;
 }) {
-  return <DashboardLayout>{children}</DashboardLayout>;
+  return (
+    <>
+      <WorkspaceSync />
+      <DashboardLayout>{children}</DashboardLayout>
+    </>
+  );
 }

--- a/src/components/__tests__/workspace-sync.test.tsx
+++ b/src/components/__tests__/workspace-sync.test.tsx
@@ -1,0 +1,120 @@
+import { render, waitFor } from "@testing-library/react";
+import { usePathname, useRouter } from "next/navigation";
+import { vi, describe, it, expect, beforeEach } from "vitest";
+import { WorkspaceSync } from "@/components/workspace-sync";
+import { useWorkspaceStore } from "@/stores/workspace.store";
+
+// Mock Next.js navigation
+vi.mock("next/navigation", () => ({
+  usePathname: vi.fn(),
+  useRouter: vi.fn(),
+}));
+
+// Mock workspace store
+vi.mock("@/stores/workspace.store", () => ({
+  useWorkspaceStore: vi.fn(),
+}));
+
+describe("WorkspaceSync", () => {
+  const mockRouter = {
+    replace: vi.fn(),
+  };
+
+  const mockWorkspaceStore = {
+    setWorkspaceBySlug: vi.fn(),
+    loadWorkspaces: vi.fn(),
+    workspaces: [],
+    currentWorkspace: null,
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    (useRouter as any).mockReturnValue(mockRouter);
+    (useWorkspaceStore as any).mockReturnValue(mockWorkspaceStore);
+    // Also mock getState
+    (useWorkspaceStore as any).getState = vi.fn().mockReturnValue(mockWorkspaceStore);
+  });
+
+  it("should sync workspace when navigating to a workspace URL", async () => {
+    (usePathname as any).mockReturnValue("/daygen/issues");
+    mockWorkspaceStore.setWorkspaceBySlug.mockResolvedValue(true);
+    mockWorkspaceStore.workspaces = [
+      { id: "1", slug: "daygen", name: "Daygen" },
+    ];
+
+    render(<WorkspaceSync />);
+
+    await waitFor(() => {
+      expect(mockWorkspaceStore.setWorkspaceBySlug).toHaveBeenCalledWith("daygen");
+    });
+  });
+
+  it("should load workspaces if none are loaded", async () => {
+    (usePathname as any).mockReturnValue("/daygen/issues");
+    mockWorkspaceStore.workspaces = [];
+    mockWorkspaceStore.loadWorkspaces.mockResolvedValue(undefined);
+    mockWorkspaceStore.setWorkspaceBySlug.mockResolvedValue(true);
+
+    render(<WorkspaceSync />);
+
+    await waitFor(() => {
+      expect(mockWorkspaceStore.loadWorkspaces).toHaveBeenCalled();
+      expect(mockWorkspaceStore.setWorkspaceBySlug).toHaveBeenCalledWith("daygen");
+    });
+  });
+
+  it("should redirect to first workspace if slug not found", async () => {
+    (usePathname as any).mockReturnValue("/invalid/issues");
+    mockWorkspaceStore.setWorkspaceBySlug.mockResolvedValue(false);
+    mockWorkspaceStore.workspaces = [
+      { id: "1", slug: "daygen", name: "Daygen" },
+    ];
+    (useWorkspaceStore as any).getState.mockReturnValue({
+      ...mockWorkspaceStore,
+      workspaces: [{ id: "1", slug: "daygen", name: "Daygen" }],
+    });
+
+    render(<WorkspaceSync />);
+
+    await waitFor(() => {
+      expect(mockRouter.replace).toHaveBeenCalledWith("/daygen/issues");
+    });
+  });
+
+  it("should redirect to login if no workspaces available", async () => {
+    (usePathname as any).mockReturnValue("/invalid/issues");
+    mockWorkspaceStore.setWorkspaceBySlug.mockResolvedValue(false);
+    mockWorkspaceStore.workspaces = [];
+    (useWorkspaceStore as any).getState.mockReturnValue({
+      ...mockWorkspaceStore,
+      workspaces: [],
+    });
+
+    render(<WorkspaceSync />);
+
+    await waitFor(() => {
+      expect(mockRouter.replace).toHaveBeenCalledWith("/login");
+    });
+  });
+
+  it("should not sync if current workspace matches URL", () => {
+    (usePathname as any).mockReturnValue("/daygen/issues");
+    mockWorkspaceStore.currentWorkspace = { id: "1", slug: "daygen", name: "Daygen" };
+    mockWorkspaceStore.workspaces = [
+      { id: "1", slug: "daygen", name: "Daygen" },
+    ];
+
+    render(<WorkspaceSync />);
+
+    expect(mockWorkspaceStore.setWorkspaceBySlug).not.toHaveBeenCalled();
+  });
+
+  it("should handle empty pathname gracefully", () => {
+    (usePathname as any).mockReturnValue("/");
+
+    render(<WorkspaceSync />);
+
+    expect(mockWorkspaceStore.setWorkspaceBySlug).not.toHaveBeenCalled();
+    expect(mockWorkspaceStore.loadWorkspaces).not.toHaveBeenCalled();
+  });
+});

--- a/src/components/workspace-sync.tsx
+++ b/src/components/workspace-sync.tsx
@@ -1,0 +1,50 @@
+"use client";
+
+import { useEffect } from "react";
+import { usePathname, useRouter } from "next/navigation";
+import { useWorkspaceStore } from "@/stores/workspace.store";
+
+export function WorkspaceSync() {
+  const pathname = usePathname();
+  const router = useRouter();
+  const { setWorkspaceBySlug, loadWorkspaces, workspaces, currentWorkspace } = useWorkspaceStore();
+
+  useEffect(() => {
+    // Extract workspace slug from pathname
+    const segments = pathname.split("/");
+    const workspaceSlug = segments[1]; // e.g., /daygen/issues -> "daygen"
+
+    if (!workspaceSlug) return;
+
+    const syncWorkspace = async () => {
+      // If no workspaces loaded yet, load them first
+      if (workspaces.length === 0) {
+        await loadWorkspaces();
+      }
+      
+      // Try to set workspace by slug
+      const found = await setWorkspaceBySlug(workspaceSlug);
+      
+      // If workspace not found, redirect to first available workspace or login
+      if (!found) {
+        const updatedWorkspaces = useWorkspaceStore.getState().workspaces;
+        if (updatedWorkspaces.length > 0) {
+          // Redirect to first workspace
+          const firstWorkspace = updatedWorkspaces[0];
+          router.replace(`/${firstWorkspace.slug}/issues`);
+        } else {
+          // No workspaces available, redirect to login
+          router.replace("/login");
+        }
+      }
+    };
+
+    // Only sync if current workspace doesn't match URL
+    if (!currentWorkspace || currentWorkspace.slug !== workspaceSlug) {
+      syncWorkspace();
+    }
+  }, [pathname, workspaces.length, currentWorkspace, setWorkspaceBySlug, loadWorkspaces, router]);
+
+  // This component doesn't render anything
+  return null;
+}


### PR DESCRIPTION
## Summary

- Fixes the "No Workspace Selected" display issue when navigating directly to workspace URLs
- Adds automatic synchronization between the URL workspace slug and the workspace store
- Ensures the workspace state is always consistent with the current URL

## Changes

1. **Enhanced Workspace Store**
   - Added `setWorkspaceBySlug` method to find and set workspace by URL slug
   - Enhanced persistence to include workspace slug for better restoration

2. **New WorkspaceSync Component**
   - Monitors URL changes and syncs workspace store accordingly
   - Handles initial load and client-side navigation
   - Includes error handling with redirects for invalid workspace URLs

3. **Integration & Testing**
   - Integrated WorkspaceSync into dashboard layout
   - Added comprehensive tests for all synchronization scenarios

## Test Plan

- [x] Navigate directly to a workspace URL (e.g., `/daygen/issues`) - workspace should be selected
- [x] Navigate between different workspace pages - workspace should remain selected
- [x] Refresh the page on a workspace URL - workspace should be restored
- [x] Navigate to an invalid workspace URL - should redirect to first workspace or login
- [x] All new tests pass for WorkspaceSync component

## Before

When navigating directly to `/daygen/issues`, the sidebar showed "No Workspace Selected" even though the user was on a valid workspace page.

## After

The workspace is automatically synced with the URL, and the sidebar correctly displays "Daygen" as the current workspace.

🤖 Generated with [Claude Code](https://claude.ai/code)