### PR TITLE
Fix: Add timeout handling to workspace sync to resolve production hang

### DIFF
--- a/src/stores/workspace.store.ts
+++ b/src/stores/workspace.store.ts
@@ -41,9 +41,26 @@ export const useWorkspaceStore = create<WorkspaceState>()(
         
         try {
           const supabase = createClient();
-          const { data: { user } } = await supabase.auth.getUser();
           
-          console.log("[WorkspaceStore] Auth user:", user?.id);
+          // Add timeout to auth check
+          const timeoutPromise = new Promise((_, reject) => 
+            setTimeout(() => reject(new Error("Auth timeout")), 5000)
+          );
+          
+          const authPromise = supabase.auth.getUser();
+          
+          let user;
+          try {
+            const authResult = await Promise.race([authPromise, timeoutPromise]) as any;
+            user = authResult?.data?.user;
+            console.log("[WorkspaceStore] Auth user:", user?.id);
+          } catch (authError) {
+            console.error("[WorkspaceStore] Auth error or timeout:", authError);
+            // Try to get session instead
+            const { data: { session } } = await supabase.auth.getSession();
+            user = session?.user;
+            console.log("[WorkspaceStore] User from session:", user?.id);
+          }
           
           if (!user) {
             console.log("[WorkspaceStore] No user found, clearing workspaces");
@@ -96,6 +113,13 @@ export const useWorkspaceStore = create<WorkspaceState>()(
             error: error instanceof Error ? error.message : "Failed to load workspaces",
             isLoading: false 
           });
+        } finally {
+          // Ensure loading state is always cleared
+          const state = get();
+          if (state.isLoading) {
+            console.log("[WorkspaceStore] Clearing loading state in finally block");
+            set({ isLoading: false });
+          }
         }
       },
 

--- a/src/stores/workspace.store.ts
+++ b/src/stores/workspace.store.ts
@@ -51,7 +51,7 @@ export const useWorkspaceStore = create<WorkspaceState>()(
           
           let user;
           try {
-            const authResult = await Promise.race([authPromise, timeoutPromise]) as any;
+            const authResult = await Promise.race([authPromise, timeoutPromise]) as Awaited<ReturnType<typeof supabase.auth.getUser>>;
             user = authResult?.data?.user;
             console.log("[WorkspaceStore] Auth user:", user?.id);
           } catch (authError) {


### PR DESCRIPTION
## Summary

This PR fixes the workspace sync issue in production where users see 'No Workspace Selected' even after the initial fix in PR #173.

## Root Cause

The supabase.auth.getUser() call was hanging indefinitely in production, preventing the workspace loading process from completing. This was visible in the console logs where loadWorkspaces was called but never progressed past the auth check.

## Solution

1. **Added timeout handling** to the getUser() call with a 5-second limit
2. **Fallback to getSession()** if getUser() times out or fails
3. **Added timeout wrapper** around the entire loadWorkspaces call in the sync process
4. **Improved error handling** to ensure the process continues even if parts fail
5. **Added finally block** to ensure loading state is always cleared

## Changes

- Modified workspace.store.ts to add timeout and fallback auth handling
- Modified workspace-sync.tsx to add timeout wrapper and better error handling
- Kept all debug logging from PR #174 for monitoring

## Testing

- Tested locally to ensure no regression
- The timeout mechanism ensures the sync process completes even if auth is slow
- Users will either see their workspace or be redirected appropriately

## Related Issues

- Fixes the issue reported after PR #173 was merged
- Builds on debugging work from PR #174

🤖 Generated with [Claude Code](https://claude.ai/code)