### PR TITLE
fix: transpile Supabase packages for production build

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -1,6 +1,7 @@
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
+  transpilePackages: ["@supabase/ssr", "@supabase/supabase-js"],
   images: {
     remotePatterns: [
       {

--- a/src/stores/workspace.store.ts
+++ b/src/stores/workspace.store.ts
@@ -123,7 +123,7 @@ export const useWorkspaceStore = create<WorkspaceState>()(
 
           if (error) throw error;
 
-          let workspaces = memberRecords
+          const workspaces = memberRecords
             ?.map(record => record.workspaces as unknown as Workspace)
             .filter(ws => ws !== null) || [];
 

--- a/src/stores/workspace.store.ts
+++ b/src/stores/workspace.store.ts
@@ -128,19 +128,6 @@ export const useWorkspaceStore = create<WorkspaceState>()(
             .filter(ws => ws !== null) || [];
 
           console.log("[WorkspaceStore] Parsed workspaces:", workspaces);
-          
-          // TEMPORARY: If no workspaces found but we have a user ID, create a demo workspace
-          if (workspaces.length === 0 && userId) {
-            console.log("[WorkspaceStore] No workspaces found, creating demo workspace");
-            workspaces = [{
-              id: 'demo-workspace',
-              name: 'Daygen',
-              slug: 'daygen',
-              created_by: userId,
-              created_at: new Date().toISOString(),
-              updated_at: new Date().toISOString()
-            }];
-          }
 
           set({ workspaces, isLoading: false });
 


### PR DESCRIPTION
## Summary
- Add `transpilePackages` configuration to `next.config.ts` to force Next.js to properly bundle Supabase libraries
- Remove temporary demo mode workarounds that were attempting to bypass the auth issues

## Problem
The Supabase client was not initializing properly in production, causing:
- Auth methods (`getUser()`, `getSession()`) to timeout after 5 seconds
- No auth cookies being set
- Users unable to access their workspaces
- "No Workspace Selected" displayed even when navigating directly to workspace URLs

## Root Cause
The investigation revealed that the Supabase client was returning in 0.1-0.4ms in production (impossibly fast), indicating it wasn't actually initializing. This was due to Next.js 15.3.5 not properly bundling the `@supabase/ssr` and `@supabase/supabase-js` packages.

## Solution
Adding `transpilePackages: ["@supabase/ssr", "@supabase/supabase-js"]` to the Next.js config forces these packages to be properly transpiled and included in the production bundle.

## Test Plan
- [ ] Deploy to Vercel
- [ ] Navigate directly to `/daygen/issues`
- [ ] Verify that the workspace loads correctly
- [ ] Check that auth methods complete successfully (no timeouts)
- [ ] Verify auth cookies are set properly

Fixes #173

🤖 Generated with [Claude Code](https://claude.ai/code)